### PR TITLE
fix(ci): improve coverage artifact reliability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,16 @@ jobs:
         run: uv run pytest tests/unit -v --strict-markers --cov=src/canvas_code_correction
           --cov-report=xml --cov-report=json:coverage.json --cov-report=term
       - name: Generate HTML coverage report
-        run: uv run coverage html --data-file=.coverage
+        run: |
+          if [ -f ".coverage" ]; then
+            uv run coverage html --data-file=.coverage
+          else
+            echo "Warning: .coverage file not found, skipping HTML report generation"
+            echo "List of files in current directory:"
+            ls -la
+          fi
+          # Ensure htmlcov directory exists even if empty
+          mkdir -p htmlcov
 
       # Upload coverage artifacts for deploy-docs workflow (short retention)
       - name: Upload coverage artifacts
@@ -65,7 +74,7 @@ jobs:
           path: |
             coverage.json
             htmlcov/
-          retention-days: 1
+          retention-days: 7
       - name: Run integration tests (requires Canvas credentials)
         if: env.CANVAS_API_TOKEN != ''
         run: |


### PR DESCRIPTION
## Summary
Improve reliability of coverage report generation and artifact retention in CI:

- **Error handling**: Check if `.coverage` file exists before generating HTML reports
- **Directory safety**: Ensure `htmlcov/` directory exists even if coverage generation fails
- **Extended retention**: Increase artifact retention from 1 to 7 days for deploy-docs workflow

## Context
These changes complement the documentation deployment fixes in #70:
- Coverage reports are now properly included in documentation via `docs/htmlcov/`
- Artifacts need to be available when deploy-docs workflow runs (may be delayed)
- Failures in coverage generation should not break artifact upload

## Testing
- Coverage HTML generation continues to work when `.coverage` exists
- If `.coverage` missing, workflow continues with warning (no hard failure)
- `htmlcov/` directory always created for artifact upload consistency
- Longer retention ensures deploy-docs can access artifacts even with workflow delays

## Related PRs
- #70: Custom domain deployment for documentation