### PR TITLE
[codex] align documentation with current workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,6 @@ source .venv/bin/activate
 ```bash
 poe fmt
 poe lint
-poe ci:fmt
 poe ci:lint
 poe check
 poe test
@@ -121,9 +120,6 @@ grades back to Canvas.
   `uv-secure`, workflow validation, and `validate-pyproject`.
 - License is MIT.
 
-> TODO: `.github/dependabot.yml` points at `/backend` and `/frontend`, which do
-> not match this repo layout.
-
 ## Agent Guardrails
 - Never edit secrets or generated state: `.env*`, `.venv/`, `.cache/`,
   `.pytest_cache/`, `.ruff_cache/`, `.scannerwork/`, `coverage.*`, `site/`,
@@ -136,8 +132,6 @@ grades back to Canvas.
 - Respect webhook rate limits; default is `10/minute`.
 - Only run integration/e2e flows against Canvas when explicit credentials are
   configured.
-
-> TODO: No repo-local approval policy was found.
 
 ## Extensibility Hooks
 - Per-course config lives in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,273 +1,209 @@
-# Contribute to Canvas Code Correction in 5 Minutes
+# Contributing
 
-Welcome to Canvas Code Correction (CCC). This guide walks you through the
-fastest way to make your first contribution—whether you’re fixing a bug, adding
-a feature, or improving documentation. Follow the steps below and you’ll have a
-pull request ready in minutes.
+This guide describes the current contributor workflow for **Canvas Code
+Correction (CCC)**. It is intentionally practical: install the dev environment,
+run the repo commands, make focused changes, and verify them before opening a
+pull request.
 
-## Quick Start: Your First Contribution
+## Try It Now
 
-### 1. Fork and Clone
-
-**Fork** the repository on GitHub, then **clone** your fork to your local
-machine:
+Set up the full development environment from the repository root:
 
 ```bash
-$ git clone https://github.com/YOUR_USERNAME/Canvas-Code-Correction.git
-$ cd Canvas-Code-Correction
+$ uv sync --all-groups
+$ source .venv/bin/activate
+$ poe all
 ```
 
-Replace `YOUR_USERNAME` with your GitHub username.
+If the environment is healthy, you will finish with passing format, lint, type,
+and unit-test checks.
 
-### 2. Install Dependencies
+## Development Setup
 
-CCC uses **uv** for dependency management. Install the project and its
-development tools with:
+### Prerequisites
+
+- **Python 3.13**
+- **uv**
+- **Docker** if you need integration or e2e coverage
+
+### Install the project
 
 ```bash
-$ uv sync
+$ uv sync --all-groups
+$ source .venv/bin/activate
 ```
 
-Expected output (truncated):
+If you do not want to activate the environment, use `uv run <command>` instead.
 
-```
-✔ Synced environment in 0.5s
-✔ Installed 42 packages
-✔ All dependencies are satisfied
-```
-
-### 3. Run the Tests
-
-Verify everything works before you make changes:
+### Verify the CLI
 
 ```bash
-$ pytest
+$ ccc --version
 ```
 
-You should see something like:
+Expected output:
 
-```
-========================== test session starts ==========================
-platform linux — Python 3.13.0, pytest‑8.3.4, pluggy‑1.5.0
-rootdir: /home/jsg/Documents/jsg/Canvas‑Code‑Correction
-collected 127 items
-
-tests/unit/test_core.py ...................................... [ 25%]
-tests/unit/test_parser.py ..................................... [ 50%]
-tests/unit/test_utils.py ...................................... [ 75%]
-tests/integration/test_integration.py ........................ [100%]
-
-=========================== 127 passed in 3.2s ==========================
+```text
+Canvas Code Correction 2.0.0a0
 ```
 
-If any test fails, check the [Troubleshooting](#troubleshooting) section.
+## Daily Workflow
 
-### 4. Make Your Changes
-
-Pick one of the common workflows below.
-
-#### Fixing a Bug
-
-1. **Find the bug** – check the issue tracker or run the failing test.
-2. **Edit the relevant file** – locate the function or module that needs fixing.
-3. **Write a test** (optional but recommended) – add a minimal test that
-   reproduces the bug, then verify your fix makes it pass.
-
-Example: fixing a typo in `src/ccc/core.py`:
-
-```python
-# Before
-def greet(user: str) -> str:
-    return f"Helo, {user}!"
-
-# After
-def greet(user: str) -> str:
-    return f"Hello, {user}!"
-```
-
-Run the tests again to ensure nothing broke:
+### Create a branch
 
 ```bash
-$ pytest tests/unit/test_core.py
+$ git switch -c <type>/<short-description>
 ```
 
-#### Adding a Feature
+Examples:
 
-1. **Create a new branch** for your feature:
+- `fix/webhook-auth-timeout`
+- `docs/update-course-setup-guide`
+- `feat/course-block-validation`
 
-   ```bash
-    $ git switch -c feat/your-feature-name main
-   ```
+### Run the standard checks
 
-2. **Implement the feature** in the appropriate module. Follow the
-   [code style guidelines](#code-style) below.
+Use the task aliases in `pyproject.toml`:
 
-3. **Add unit tests** for the new functionality. Place them in the corresponding
-   test file (e.g., `tests/unit/test_core.py`).
+```bash
+$ poe fmt
+$ poe lint
+$ poe check
+$ poe test
+```
 
-4. **Run the full test suite** to confirm everything passes:
+Or run the full local gate:
 
-   ```bash
-   $ pytest
-   ```
+```bash
+$ poe all
+```
 
-#### Improving Documentation
+### Test scopes
 
-1. **Find the documentation source** – most docs live in `docs/` and are written
-   in Markdown.
+Default `pytest` excludes integration and e2e markers. Run the larger suites
+explicitly when your changes touch those paths.
 
-2. **Edit the file** – correct typos, clarify explanations, or add missing
-   examples.
+Unit tests:
 
-3. **Preview your changes** locally with the docs server:
+```bash
+$ uv run pytest tests/unit -v --strict-markers
+```
 
-   ```bash
-   $ poe serve-docs
-   ```
+Integration tests:
 
-   Open `http://localhost:8000` in your browser to verify the updates.
+```bash
+$ uv run pytest tests/integration -v --strict-markers -m integration --no-cov
+```
 
-### 5. Submit a Pull Request
+End-to-end tests:
 
-1. **Commit your changes** with a clear, conventional commit message:
-
-   ```bash
-   $ git add .
-   $ git commit -m "fix(core): correct greeting typo"
-   ```
-
-2. **Push** to your fork:
-
-   ```bash
-   $ git push origin feat/your-feature-name
-   ```
-
-3. **Open a pull request** on GitHub against the `main` branch. Fill in the PR
-   template with a description of what you changed and why.
-
-4. **Wait for CI** – the automated checks (tests, linting, formatting) will run.
-   If they pass, a maintainer will review your PR. Address any feedback by
-   pushing additional commits to the same branch.
+```bash
+$ poe test-e2e
+```
 
 ## Code Style
 
-CCC follows **PEP 8** and uses automated tools to keep the code consistent.
+### Formatting and linting
 
-### Formatting with Black
-
-Run **Black** before committing to auto‑format your Python code:
+CCC uses **Ruff** for formatting and linting.
 
 ```bash
-$ black .
+$ ruff format
+$ ruff check --fix
 ```
 
-Example of Black‑compliant style:
-
-```python
-from typing import Optional
-
-def calculate_total(items: list[float], discount: Optional[float] = None) -> float:
-    """Return the total price after applying an optional discount."""
-    subtotal = sum(items)
-    if discount is not None:
-        subtotal -= subtotal * discount
-    return subtotal
-```
-
-### Linting with Ruff
-
-**Ruff** catches common mistakes and enforces style rules. Run it to see any
-issues:
+CI-friendly variants:
 
 ```bash
-$ ruff check .
+$ ruff check
+$ pyrefly check
 ```
 
-Fix any warnings or errors before submitting your PR.
+### Python requirements
 
-### Type Hints
+- Target **Python 3.13** only.
+- Use **type hints** throughout.
+- Keep public interfaces explicit and small.
+- Prefer updating the existing flow/CLI/service modules over adding parallel
+  abstractions.
 
-Use **type hints** for all function parameters and return values. They are
-treated as first‑class documentation.
+### Tests
 
-```python
-# Good
-def parse_config(path: str) -> dict[str, Any]:
-    ...
+- Put unit tests in `tests/unit/`.
+- Put integration tests in `tests/integration/`.
+- Put e2e tests in `tests/e2e/`.
+- Do not use `autouse=True` fixtures. `tests/AGENTS.md` repeats this rule.
 
-# Avoid (no types)
-def parse_config(path):
-    ...
-```
+## Documentation Changes
 
-### Docstrings
+If you change docs, use [.docs-style-checklist.md](.docs-style-checklist.md).
+At minimum, each affected page should:
 
-Write **docstrings** for public functions, classes, and modules. Use the
-triple‑quote Google style:
+- start with a clear goal or quick-start section
+- use the current command names and flags from the codebase
+- show expected output when it adds clarity
+- link to the adjacent docs that readers need next
 
-```python
-def encode_data(data: bytes, key: str) -> bytes:
-    """Encrypt the given data with the provided key.
-
-    Args:
-        data: Raw bytes to encrypt.
-        key: Secret encryption key.
-
-    Returns:
-        Encrypted bytes.
-
-    Raises:
-        ValueError: If the key length is invalid.
-    """
-    ...
-```
-
-## Testing
-
-### Unit Tests
-
-Place unit tests in `tests/unit/`. Each test file should mirror the module it
-tests (e.g., `test_core.py` for `core.py`). Use `pytest` fixtures and
-parameterization where helpful.
-
-Example test:
-
-```python
-def test_greet() -> None:
-    from ccc.core import greet
-    assert greet("world") == "Hello, world!"
-```
-
-### Integration Tests
-
-Integration tests live in `tests/integration/` and require Docker and RustFS.
-Run them separately with:
+Preview or rebuild docs with:
 
 ```bash
-$ pytest -m integration
+$ poe serve-docs
+$ uv run zensical build --strict --clean
 ```
 
-If you don’t have Docker installed, you can skip these tests; CI will run them
-for your PR.
+## Common Change Patterns
+
+### Bug fixes
+
+1. Reproduce the problem with a focused test or command.
+2. Patch the implementation.
+3. Add or update a regression test.
+4. Re-run the narrow test first, then `poe all`.
+
+### CLI changes
+
+If you change `src/canvas_code_correction/cli*.py`, update:
+
+- `README.md`
+- `docs/reference/02-cli.md`
+- any platform setup page that shows the changed command
+
+### Docs-only changes
+
+Run at least:
+
+```bash
+$ uv run zensical build --strict --clean
+```
+
+## Pull Requests
+
+Before you open a PR:
+
+1. Keep the branch focused.
+2. Use a conventional commit message, for example `docs(reference): align cli flags`.
+3. Summarize the user-visible change and any verification you ran.
+4. Note any checks you could not run.
+
+Typical commit flow:
+
+```bash
+$ git add <files>
+$ git commit -m "docs(reference): align course setup flags"
+$ git push origin <branch>
+```
 
 ## Troubleshooting
 
-| Problem                           | Solution                                                                                                                         |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `uv sync` fails                   | Ensure you have **uv** installed (`curl -LsSf https://astral.sh/uv/install.sh                                                    | sh`). |
-| Tests pass locally but fail in CI | Run `ruff check .` and `black --check .` to catch lint/format issues.                                                            |
-| Integration tests require Docker  | Install Docker from [docker.com](https://docker.com). If you can’t run them, note in your PR that you skipped integration tests. |
-| `poe serve-docs` fails            | Make sure the `docs` extra is installed: `uv sync --extra docs`.                                                                 |
-| Git push rejected                 | Fetch upstream changes and rebase: `git fetch upstream main && git rebase upstream/main`.                                        |
+| Problem | What to check |
+| --- | --- |
+| `uv sync` fails | Confirm your Python toolchain supports 3.13 and that `uv` is installed correctly. |
+| `ccc` is not found | Activate `.venv` or prefix the command with `uv run`. |
+| Integration tests fail immediately | Ensure RustFS and any required Canvas credentials are configured. |
+| e2e tests fail before running assertions | Start the docker-compose stack through `poe test-e2e` or bring the services up manually. |
+| Docs build fails | Fix the broken link, malformed Markdown, or bad admonition syntax and rerun `uv run zensical build --strict --clean`. |
 
-## Code of Conduct
+## Need Help
 
-Be respectful and inclusive. This project follows the
-[Contributor Covenant](https://www.contributor-covenant.org/). Instances of
-abusive, harassing, or otherwise unacceptable behavior may be reported to the
-project maintainers.
-
----
-
-**Need help?** Open an issue on GitHub or join the discussion in the project’s
-community channels.
+Open an issue or draft PR with the failing command, the exact output, and the
+files you were changing.

--- a/README.md
+++ b/README.md
@@ -10,373 +10,192 @@
 
 # Canvas Code Correction
 
-**Modern orchestration for downloading, grading, and uploading Canvas
-submissions using Prefect, Docker, and reproducible local workspaces.**
+**Canvas Code Correction (CCC)** orchestrates Canvas grading workflows with
+**Prefect**, **Docker**, and **S3-compatible asset storage**. It gives you one
+repo for course setup, manual grading runs, webhook intake, worker execution,
+and Canvas uploads.
 
-## Try It Now (60 Seconds)
+## Try It Now
 
-Copy and run these commands to install CCC and verify it works:
+Copy and run this from the repository root:
 
 ```bash
-# Clone the repository
-$ git clone https://github.com/<your-org>/canvas-code-correction.git
-$ cd canvas-code-correction
-
-# Install dependencies with uv (Python 3.13+)
 $ uv sync
-
-# Activate the virtual environment
 $ source .venv/bin/activate
-
-# Verify the CLI is ready
 $ ccc --help
 ```
 
-!!! note All commands assume you have activated the virtual environment created
-by `uv sync`. If you haven't activated it, prefix commands with `uv run`. This
-example shows activation via `source .venv/bin/activate`; you can also use
-`uv shell` or prefix individual commands with `uv run`.
+Expected output starts like this:
 
-You’ll see:
-
-```bash
+```text
 Usage: ccc [OPTIONS] COMMAND [ARGS]...
 
-Options:
-  --version  Show version information.
-  --help     Show this message and exit.
-
-Commands:
-  course  Course administration commands.
-  system  Platform administration commands.
+Canvas Code Correction CLI
 ```
 
-If you see the help text, **CCC is installed and ready**. The next step is to
-configure your first course.
+If you prefer not to activate the virtual environment, prefix commands with
+`uv run`, for example `uv run ccc --help`.
 
-## Quick Tutorial (5 Minutes)
+## Operator Workflow
 
-This tutorial walks you through setting up CCC and grading your first
-assignment. You’ll need:
+### 1. Configure a course
 
-- **Canvas API token** with sufficient permissions
-- **Canvas course ID** (numeric)
-- **Docker** (for running grader containers)
-
-### 1. Configure Your First Course
-
-Use `ccc course setup` to create a course configuration block. The configuration
-is stored as a Prefect block and can be reused across runs.
-
-Security note: avoid putting tokens directly in shell history. Prefer
-interactive input or stdin.
+Use `ccc course setup` to create a `ccc-course-<slug>` Prefect block that
+stores the Canvas connection, grader image, asset block, asset prefix, and work
+pool name.
 
 ```bash
-$ ccc course setup \
-  --slug cs101 \
-  --course-id 12345 \
-  --assets-block course-assets-cs101 \
-  --docker-image yourusername/canvas-grader:latest \
-  --s3-prefix graders/cs101/
-```
-
-Non-interactive secure token example:
-
-```bash
-$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
-  --slug cs101 \
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
   --token-stdin \
+  --api-url https://canvas.example.edu \
   --course-id 12345 \
+  --slug cs101 \
   --assets-block course-assets-cs101 \
-  --docker-image yourusername/canvas-grader:latest \
-  --s3-prefix graders/cs101/
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101
 ```
 
-**What this does:**
+Expected output includes:
 
-- Creates a Prefect block named `ccc-course-cs101`
-- Stores your Canvas token, course ID, and grader image reference
-- Links to an S3 bucket block (`course-assets-cs101`) for grader assets
-
-If you omit `--token`, you’ll be prompted to enter it securely.
-
-**Verify the configuration:**
-
-```bash
-$ ccc course list
+```text
+✓ Canvas access validated successfully
+✓ Course ID 12345 validated
+✓ Course configuration saved as block: ccc-course-cs101
 ```
 
-Expected output:
+### 2. Run a correction manually
 
-```
-Configured courses:
-- cs101 (course ID: 12345, image: yourusername/canvas-grader:latest)
-```
-
-### 2. Run a Correction Manually
-
-Test your setup by grading a specific assignment. Replace `98765` with your
-actual Canvas assignment ID.
+Use `ccc course run` for batch or single-submission runs.
 
 ```bash
 $ ccc course run 98765 --course ccc-course-cs101
 ```
 
-**What happens:**
-
-1. **Downloads** all submissions for assignment `98765`
-2. **Runs** the grader Docker image on each submission
-3. **Uploads** feedback and grades to Canvas
-
-You’ll see progress output like:
-
-```
-📥 Downloading submissions for assignment 98765...
-✅ Downloaded 42 submissions
-🏃 Running graders in Docker containers...
-  ████████████████████████████████████ 100% (42/42)
-📊 Results: 40 passed, 2 failed
-📤 Uploading feedback to Canvas...
-🎉 Done! Grades posted for 40 students
-⏱️  Total time: 18.3 seconds
-```
-
-To grade a single submission (dry‑run mode), add `--submission-id`:
+Or limit the run to one submission:
 
 ```bash
-$ ccc course run 98765 --submission-id 54321 --dry-run
+$ ccc course run 98765 --course ccc-course-cs101 --submission-id 54321 --dry-run
 ```
 
-### 3. Start the Webhook Server (Optional)
+Single-submission output includes a JSON summary with downloaded files,
+workspace path, and result keys.
 
-For automatic grading when students submit, start the webhook server:
+### 3. Start the webhook server
 
 ```bash
 $ ccc system webhook serve --host 0.0.0.0 --port 8080
 ```
 
-The server listens for Canvas webhook events and triggers the correction flow.
-You’ll need to configure Canvas to send events to this endpoint.
+Expected output:
 
-### 4. Create a Prefect Deployment (Optional)
+```text
+Starting webhook server on 0.0.0.0:8080
+```
 
-To run corrections via Prefect’s scheduler or API, create a deployment. First,
-ensure your Prefect server is running (see **Installation & Setup** below).
+### 4. Create the Prefect deployment
+
+CCC creates the webhook-oriented deployment for you:
 
 ```bash
 $ ccc system deploy create ccc-course-cs101
 ```
 
-This registers a deployment that can be triggered by webhooks or manually
-through the Prefect UI.
+Expected output includes:
 
----
+```text
+Creating deployment for course block: ccc-course-cs101
+Deployment 'ccc-cs101-deployment' created/updated successfully
+```
 
-## Installation & Setup
+### 5. Start a worker
+
+The worker must listen on the same work pool stored in the course block:
+
+```bash
+$ uv run prefect worker start --pool course-work-pool-cs101
+```
+
+## Installation
 
 ### Prerequisites
 
-- [uv](https://docs.astral.sh/uv/) (manages Python toolchain and dependencies)
-- Python 3.13 (automatically provisioned by `uv sync`)
-- Canvas API token and course identifiers with sufficient permissions
-- Docker (for running grader containers)
+- **Python 3.13**
+- **uv**
+- **Docker**
+- A **Canvas API token**
+- A reachable **Prefect API** for block storage and deployments
 
-### Installation
+### Environment file
 
-1. Clone the repository and enter it:
+Copy `.env.example` when you need a local baseline:
 
-   ```bash
-   $ git clone https://github.com/<your-org>/canvas-code-correction.git
-   $ cd canvas-code-correction
-   ```
+```bash
+$ cp .env.example .env
+```
 
-2. Provision dependencies and the virtual environment with uv:
+Common values:
 
-   ```bash
-   $ uv sync
-   ```
+```dotenv
+CANVAS_API_URL=https://canvas.instructure.com
+CANVAS_API_TOKEN=your_canvas_api_token_here
+PREFECT_API_URL=http://localhost:4200/api
+```
 
-3. Create a `.env` file (copy `.env.example` or request credentials) and provide
-   the following values:
+For local RustFS testing, uncomment the `RUSTFS_*` entries in `.env.example` or
+use `.env.dev`.
 
-   ```dotenv
-   CANVAS_API_URL=https://canvas.instructure.com
-   CANVAS_API_TOKEN=your_token
-   CANVAS_COURSE_ID=123456
-   # optional overrides
-   CCC_WORKING_DIR=/absolute/path/to/var/runs
-   # RustFS configuration (for integration tests)
-   # RUSTFS_ENDPOINT=http://localhost:9000
-   # RUSTFS_ACCESS_KEY=rustfsadmin
-   # RUSTFS_SECRET_KEY=rustfsadmin
-   # RUSTFS_BUCKET_NAME=test-assets
-   # RUSTFS_PREFIX=dev
-   ```
+## Development Commands
 
-4. Verify the CLI is working:
+The repo standard commands live in `pyproject.toml`:
 
-   ```bash
-   $ ccc --help
-   ```
+```bash
+$ poe fmt
+$ poe lint
+$ poe check
+$ poe test
+$ poe all
+```
 
-### Prefect Server (Optional)
-
-For local development, start a Prefect server:
+Useful extras:
 
 ```bash
 $ poe prefect
-```
-
-This starts Prefect's UI at `http://localhost:4200`. The CLI commands interact
-with this server to store blocks and create deployments.
-
-## Interactive Tutorial
-
-This tutorial walks you through the main features of Canvas Code Correction
-using the Typer‑based CLI.
-
-### 1. Configure Your First Course
-
-Use `ccc course setup` to create a course configuration block. You'll need:
-
-- Canvas API token
-- Canvas course ID
-- Prefect S3 bucket block name (for grader assets) – create one via Prefect UI
-  or CLI
-
-```bash
-printf "%s" "$CANVAS_API_TOKEN" | uv run ccc course setup \
-  --no-interactive \
-  --token-stdin \
-  --api-url https://canvas.example.edu \
-  --course-id 12345 \
-  --docker-image yourusername/canvas-grader:latest
-```
-
-The command will prompt for values in interactive mode if you omit the non-
-interactive flags. The configuration is stored as a Prefect course block.
-
-List all configured courses:
-
-```bash
-uv run ccc course list
-```
-
-### 2. Run a Correction Manually
-
-Test your setup by grading a specific assignment:
-
-```bash
-uv run ccc course run 98765 --course ccc-course-cs101
-```
-
-This downloads all submissions for assignment ID 98765, runs the grader Docker
-image on each, and uploads feedback to Canvas.
-
-To grade a single submission (dry‑run mode):
-
-```bash
-uv run ccc course run 98765 --course ccc-course-cs101 --submission-id 54321 --dry-run
-```
-
-### 3. Start the Webhook Server
-
-For automatic grading when students submit, start the webhook server:
-
-```bash
-uv run ccc system webhook serve --host 0.0.0.0 --port 8080
-```
-
-The server listens for Canvas webhook events and triggers the correction flow.
-You'll need to configure Canvas to send events to this endpoint.
-
-### 4. Create a Prefect Deployment
-
-To run corrections via Prefect's scheduler or API, create a deployment. Ensure
-your Prefect server is running (see Quick Start).
-
-```bash
-uv run ccc system deploy create ccc-course-cs101
-```
-
-This registers a deployment that can be triggered by webhooks or manually
-through the Prefect UI.
-
-## Security Features
-
-Recent improvements make CCC secure by default:
-
-- **PostgreSQL password hardening**: No default passwords in docker‑compose.yml
-- **Regex DoS protection**: Fixed vulnerable patterns in submission parsing
-- **S3 bucket ownership**: Added `ExpectedBucketOwner` to prevent
-  misconfigurations
-- **Docker security**: Extended `.dockerignore` to exclude `.env*` files
-- **Test security**: Removed hardcoded tokens and HTTP URLs from tests
-- **Comprehensive test coverage**: 100% coverage for critical modules (runner,
-  auth, workspace) with integration tests for resource limits and error handling
-
-## Testing & Development
-
-### Running Tests
-
-Execute the full test suite and lint before opening a pull request:
-
-```bash
-$ prek run
-$ pytest
-$ ruff check
-$ uv run poe ci:audit
-```
-
-Test coverage reports are generated automatically (`--cov-report=term-missing`).
-Critical modules have 100% coverage, and integration tests verify real S3
-operations with RustFS mocks. Dependency auditing now uses `uv audit` against
-`uv.lock`.
-
-#### Integration Tests with RustFS
-
-For end‑to‑end integration tests, start the local RustFS S3‑compatible storage:
-
-```bash
 $ poe s3
 $ poe rustfs-setup
-$ pytest -m integration
+$ uv run zensical build --strict --clean
 ```
 
-Integration tests use mock S3Bucket fixtures to avoid Prefect block registration
-requirements, allowing tests to run against a real S3‑compatible endpoint
-without external dependencies.
-
-#### End‑to‑End Tests
-
-Comprehensive e2e tests require a running RustFS server and Prefect server:
+Integration and e2e commands:
 
 ```bash
+$ uv run pytest tests/integration -v --strict-markers -m integration --no-cov
 $ poe test-e2e
 ```
 
-To start the services manually instead, run:
+## Project Layout
 
-```bash
-$ docker compose up -d rustfs postgres redis prefect-server prefect-services
-$ pytest -m e2e
-```
+- `src/canvas_code_correction/` application code
+- `docs/` user and operator documentation
+- `tests/` unit, integration, and e2e suites
+- `scripts/` helper utilities, including RustFS setup
 
 ## Documentation
 
-Detailed documentation is available in the `docs/` directory:
+Start here:
 
+- [Documentation Index](docs/index.md)
 - [Architecture Overview](docs/reference/01-architecture.md)
 - [CLI Reference](docs/reference/02-cli.md)
-- [Configuration Guide](docs/reference/03-configuration.md)
-- [Platform Setup](docs/platform-setup/) – for operators
-- [Tutorial](docs/tutorial/) – for course responsible
+- [Configuration Reference](docs/reference/03-configuration.md)
+- [Platform Setup](docs/platform-setup/01-configuring-course.md)
+- [Tutorial](docs/tutorial/index.md)
 
 ## Contributing
 
-We welcome contributions that improve reliability, performance, or ergonomics.
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on development
-setup, code style, testing, and the pull request process.
+Use the workflow in [CONTRIBUTING.md](CONTRIBUTING.md). If you edit docs, apply
+the repository checklist in [.docs-style-checklist.md](.docs-style-checklist.md)
+and rebuild the docs before opening a PR.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,12 @@ without external dependencies.
 Comprehensive e2e tests require a running RustFS server and Prefect server:
 
 ```bash
+$ poe test-e2e
+```
+
+To start the services manually instead, run:
+
+```bash
 $ docker compose up -d rustfs postgres redis prefect-server prefect-services
 $ pytest -m e2e
 ```

--- a/docs/current-development/01-roadmap.md
+++ b/docs/current-development/01-roadmap.md
@@ -2,10 +2,10 @@
 
 ## Current Status
 
-The Canvas Code Correction project is undergoing a v2 rewrite from a legacy
-bash‑based system to a modern Prefect‑based architecture. **All planned
-milestones are now complete**: the core platform is fully functional and ready
-for production use.
+Canvas Code Correction has completed its v2 rewrite from a legacy bash-based
+system to a modern Prefect-based architecture. **All planned milestones are now
+complete** and the codebase has moved into ongoing maintenance and incremental
+improvement.
 
 You can:
 

--- a/docs/current-development/02-phase-2-migration-plan.md
+++ b/docs/current-development/02-phase-2-migration-plan.md
@@ -1,232 +1,101 @@
-# Phase 2 – Canvas Client Migration Plan
+# Phase 2 Migration Plan
 
-This document is your actionable guide for migrating from the legacy bash+Python
-tooling to a Prefect‑based orchestration system. It provides step‑by‑step
-instructions, verification commands, and the current implementation status.
+This document is now a **historical alignment note** for the v1 to v2
+migration. The migration work is complete; the value of this page is to explain
+how the legacy bash-based pipeline maps to the code that exists today.
 
-!!! note "Before you start"
-    Review the [project roadmap](01-roadmap.md) to understand the broader context.
+## Current Outcome
 
-## Migration Overview
+The migration landed on a Python 3.13 codebase built around:
 
-Your goal is to replace the existing `canvas-code-correction.sh` orchestrator
-and its supporting scripts with a modular Python pipeline orchestrated by
-Prefect. The migration preserves all essential features of the legacy system
-while adding container‑based isolation, robust error handling, and extensible
-workflow management.
+- `canvas_code_correction.clients.canvas_resources`
+- `canvas_code_correction.flows.correction`
+- `canvas_code_correction.flows.workspace`
+- `canvas_code_correction.flows.runner`
+- `canvas_code_correction.flows.collector`
+- `canvas_code_correction.flows.uploader`
+- `canvas_code_correction.webhooks.*`
 
-**Key outcomes**:
+The live operator workflow is described in:
 
-- **Canvas API client** with retry logic and typed responses
-- **Submission workspace management** that mirrors the existing download/unzip
-  contract
-- **Containerised grader execution** with configurable resource limits
-- **Idempotent upload** of feedback and grades
-- **End‑to‑end Prefect flow** that integrates all components
+- [Configuring a Course](../platform-setup/01-configuring-course.md)
+- [Setting Up Prefect](../platform-setup/02-setting-up-prefect.md)
+- [Monitoring Results](../platform-setup/04-monitoring-results.md)
 
-All components are already implemented and tested. This guide walks you through
-the migration steps, shows you how to verify each component, and points out
-remaining open questions.
+## Legacy-to-Current Mapping
 
-## 1. Legacy Feature Inventory
+| Legacy concern | Current implementation |
+| --- | --- |
+| Canvas API access | `clients/canvas_resources.py` and course settings |
+| Workspace preparation | `flows/workspace.py` |
+| Docker grader execution | `flows/runner.py` |
+| Result collection | `flows/collector.py` |
+| Canvas uploads | `flows/uploader.py` |
+| End-to-end orchestration | `flows/correction.py` |
+| Webhook intake | `webhooks/server.py`, `webhooks/handler.py`, `webhooks/auth.py` |
+| Deployment management | `webhooks/deployments.py` and `ccc system deploy create` |
 
-The table below lists the legacy features you must preserve. Every row has been
-addressed in the new implementation.
+## What Replaced the Old Manual Steps
 
-| Scope                                   | Legacy Implementation                                     | Parity Notes                                                                                                                          |
-| --------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Assignment discovery & folder bootstrap | `setup-assignment-folders.sh`, `init-config.sh`           | Reads Canvas via `CanvasClient` and populates local directories using `SubmissionStore`.                                              |
-| Submission download                     | `download_submissions.py`                                 | Supports filtering, pagination, and MD5‑based file naming via `CanvasClient` and `SubmissionStore`.                                   |
-| Extraction/normalisation                | `submissions_unzip.py`, `process_submissions.sh`          | Handles zip unpacking and folder flattening inside `SubmissionStore`.                                                                 |
-| Grading execution                       | `submissions_correcting.sh`, user‑provided `code/main.sh` | Executes instructor code inside a Docker container via `GraderExecutor`; supports timeouts, parallelism, and firejail‑like isolation. |
-| Result packaging                        | `zip_submission`, `submissions_correcting.sh`             | Produces `<handin>+.zip` artefacts and `<handin>_points.txt` via `ResultCollector`.                                                   |
-| Comment upload                          | `upload_comments.py`                                      | Idempotent upload with MD5+filename duplicate detection, handled by `CanvasUploader`.                                                 |
-| Grade upload                            | `upload_grades.py`                                        | Reads points files and applies config‑specified grading mode (score vs complete) via `CanvasUploader`.                                |
-| Cleanup                                 | `delete_submissions.py`                                   | Removes local submissions on demand (still manual; can be added as a Prefect task).                                                   |
-| Analytics                               | `plot_scores.py`, `hclust.py`, `plagiarism-check.sh`      | Non‑critical for MVP; hooks are preserved for future implementation.                                                                  |
+### Course configuration
 
-**Supporting utilities**:
-
-- **`canvas_helpers.py`** → replaced by `CanvasClient`
-- **`config2shell`/`.config_array`** → replaced by environment‑variable‑based
-  `Settings` models
-- **`canvas-code-correction.sh`** → replaced by `correct_submission_flow`
-  Prefect flow
-
-## 2. Course Fixture & Test Data
-
-All functional tests rely on a shared Canvas development course. Follow these
-steps to set up your test environment:
-
-1. **Obtain a Canvas API token** and store it as `CANVAS_API_TOKEN` in your
-   project‑level `.env` file.
-2. **Set the course ID** as `CANVAS_COURSE_ID` in the same `.env` file.
-3. **Use the development course** at
-   <https://canvas.instructure.com/courses/13121974> for testing.
-4. **Add new fixtures dynamically** via the Canvas API; capture resulting IDs in
-   `.env` for repeatability.
-
-!!! note "Important"
-    The repository does **not** depend on static IMSCC exports.  All test data is retrieved live
-    from the Canvas API.
-
-## 3. Target Architecture (Prefect‑driven)
-
-The new system is built around six core Python components:
-
-| Component               | Responsibility                                                                                                                                        |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **CanvasClient**        | Thin wrapper around the Canvas REST API with retry/backoff and typed responses (uses `canvasapi`).                                                    |
-| **SubmissionStore**     | Manages the local filesystem workspace (`var/runs/<assignment>/<submission>`); handles download, extraction, and normalisation.                       |
-| **GraderExecutor**      | Executes grading inside a clean Docker container, mounts the workspace, injects instructor code, and enforces resource limits (CPU, memory, network). |
-| **ResultCollector**     | Normalises grader outputs into the expected `points.txt`, `comments.txt`, `artifacts/` structure.                                                     |
-| **CanvasUploader**      | Uploads comments and grades idempotently, maintaining audit logs and duplicate detection via MD5 hashing.                                             |
-| **Reporter** (optional) | Analytics hook for grade summaries, plotting triggers, etc.                                                                                           |
-
-**Prefect orchestration flow**:
-
-```text
-Event / trigger (manual CLI, webhook, schedule)
-  → Flow: correct_submission_flow
-      → Task: fetch_submission_metadata
-      → Task: prepare_workspace
-      → Task: download_submission_files (CanvasClient → SubmissionStore)
-      → Task: stage_instructor_code (from repo or artifact registry)
-      → Task: run_grader_command (GraderExecutor)
-      → Task: collect_results
-      → Task: upload_comment
-      → Task: upload_grade
-      → Task: publish_run_summary
-```
-
-## 4. Incremental Migration Steps
-
-All steps below are **completed** and verified. Use the verification commands to
-confirm your environment matches the expected state.
-
-### Step 1: Configuration groundwork ✅
-
-**What you did**: Migrated configuration from INI files and bash arrays to
-environment‑variables validated by Pydantic `Settings` models.
-
-**Verification**:
+Old migration notes often referred to ad hoc environment files or shell
+wrappers. The supported path is now:
 
 ```bash
-$ grep -E '^CANVAS_' .env
-CANVAS_API_TOKEN=...
-CANVAS_COURSE_ID=...
+$ ccc course setup
 ```
 
-### Step 2: Canvas client & download ✅
+### Deployment creation
 
-**What you did**: Implemented `CanvasClient` wrapping `canvasapi` for submission
-metadata and attachment download.
-
-**Verification**:
+Old migration notes referred to hand-written Prefect deployment build commands.
+The supported path is now:
 
 ```bash
-$ uv run --group tests pytest src/canvas_client/ -xvs -k test_download
+$ ccc system deploy create ccc-course-cs101
 ```
 
-### Step 3: Workspace preparation ✅
+### Local storage for testing
 
-**What you did**: Built `SubmissionStore` that handles extraction,
-normalisation, and workspace layout.
-
-**Verification**:
+Use the repository helpers:
 
 ```bash
-$ uv run --group tests pytest src/submission_store/ -xvs
+$ poe s3
+$ poe rustfs-setup
 ```
 
-### Step 4: Runner integration ✅
+### Local validation
 
-**What you did**: Implemented `GraderExecutor` (Docker‑based execution) and
-`ResultCollector` (output packaging).
-
-**Verification**:
+Use the repo tasks:
 
 ```bash
-$ uv run --group tests pytest src/runner/ -xvs
-$ uv run --group tests pytest src/result_collector/ -xvs
+$ poe all
+$ uv run zensical build --strict --clean
 ```
 
-### Step 5: Uploader tasks ✅
+## Verification Commands
 
-**What you did**: Created `CanvasUploader` for idempotent feedback and grade
-uploads with MD5 duplicate detection.
-
-**Verification**:
+These commands match the current repository layout:
 
 ```bash
-$ uv run --group tests pytest src/uploader/ -xvs
+$ uv run pytest tests/unit -v --strict-markers
+$ uv run pytest tests/integration -v --strict-markers -m integration --no-cov
+$ poe test-e2e
 ```
 
-### Step 6: End‑to‑end Prefect flow ✅
+## Remaining Historical Notes
 
-**What you did**: Integrated all components into `correct_submission_flow`
-(download → workspace → execution → collection → upload).
+The original migration goals around container isolation, typed settings,
+webhooks, and RustFS-backed local storage are all reflected in the current
+codebase. What changed most since the early migration notes is the operator
+surface:
 
-**Verification**:
+- course setup is CLI-first through `ccc`
+- deployment creation is CLI-first through `ccc`
+- the built-in deployment is webhook-oriented, not a generic cron batch runner
 
-```bash
-$ uv run --group tests pytest tests/e2e/ -xvs
-```
+## Related Docs
 
-### Step 7: Testing & documentation ✅
-
-**What you did**: Executed the full test suite (`uv run --group tests pytest`)
-and established pre‑commit hooks. All unit tests pass as of January 2026.
-
-**Verification**:
-
-```bash
-$ uv run --group tests pytest --cov --cov-report=term-missing
-```
-
-## 5. Non‑goals for This Iteration
-
-- **Automated Canvas course cloning/reset** – remains manual.
-- **Webhook listener/service deployment** – follow after the core workflow is
-  stable.
-- **Full analytics/visualisation parity** – defer until the grading loop is
-  stable.
-- **Multi‑run scheduling/daemon replacement** – address after the single‑run
-  path is reliable.
-
-## 6. Open Questions / Follow‑ups
-
-1. **Instructor code packaging** – store in repo, S3, or separate artifact?
-   (short‑term: repository folder copied into workspace.)
-2. **Secrets management** – continue with local `.env`, but plan migration to
-   Prefect blocks / Vault later.
-3. **Container image build pipeline** – need CI job to build/publish grader
-   image tagged with repo commit.
-4. **Student code limits** – confirm CPU/memory/time defaults with teaching
-   team; codify in settings.
-5. **Roll‑forward strategy** – plan data migration for existing feedback
-   archives (if needed).
-6. **Prefect assets cataloguing** – revisit in Phase 3 once long‑term run
-   lineage requirements are defined.
-7. **CI & operational runbooks** – document Prefect worker setup and add CI
-   pipelines to execute tests/linters before Phase 3 launch.
-
-## 7. Recent Updates (January 2026)
-
-- **RustFS Integration**: Added configurable RustFS S3‑compatible storage
-  support via environment variables (`RUSTFS_ENDPOINT`, `RUSTFS_ACCESS_KEY`,
-  `RUSTFS_SECRET_KEY`, `RUSTFS_BUCKET_NAME`, `RUSTFS_PREFIX`). Updated
-  `setup‑rustfs.py` script and documentation.
-- **Comprehensive Test Suite**: Added end‑to‑end test suite (`tests/e2e/`) with
-  pytest fixtures for docker‑compose stack (RustFS, Prefect). Tests verify the
-  full pipeline: Canvas download → workspace preparation → Docker execution →
-  result collection → Canvas upload.
-- **CI/CD Pipeline**: Added GitHub Actions workflow for automated testing with
-  RustFS service, unit tests, integration tests, and e2e tests.
-- **Production Configuration**: Updated Prefect S3 block registration to support
-  custom endpoints via `AwsClientParameters`.
-
----
-
-This migration plan keeps scope narrow, focuses on essential parity, and paves
-the way for Prefect‑based orchestration without overengineering.
+- [Roadmap](01-roadmap.md)
+- [Architecture Overview](../reference/01-architecture.md)
+- [CLI Reference](../reference/02-cli.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,246 +1,100 @@
-# Canvas Code Correction v2
+# Canvas Code Correction
 
-**Try It Now** (60 seconds)
+**Canvas Code Correction (CCC)** automates Canvas grading with **Prefect**,
+**Docker**, and **S3-compatible asset storage**.
 
-!!! note "Virtual Environment"
-    All commands in this documentation assume you have activated the virtual environment created by
-    `uv sync`. If you haven't activated it, prefix commands with `uv run`. To activate:
+## Try It Now
 
-    ```bash
-    source .venv/bin/activate
-    ```
-
-    Or use `uv shell` to start a new shell with the environment activated.
-
-Copy and paste this command to run a quick test that verifies your environment
-is ready:
+Verify a fresh checkout in under a minute:
 
 ```bash
-$ pytest tests/unit/test_workspace.py -v
-```
-
-You will see output similar to:
-
-```
-============================= test session starts ==============================
-platform linux -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0
-cachedir: .pytest_cache
-rootdir: /home/jsg/Documents/jsg/Canvas-Code-Correction
-configfile: pyproject.toml
-plugins: anyio-4.12.1, cov-7.0.0, datadir-1.8.0, xdist-3.8.0
-collecting ... collected 9 items
-
-tests/unit/test_workspace.py::test_workspace_config PASSED               [ 11%]
-tests/unit/test_workspace.py::test_workspace_paths PASSED                [ 22%]
-tests/unit/test_workspace.py::test_build_workspace_config PASSED         [ 33%]
-...
-tests/unit/test_workspace.py::test_prepare_workspace_submission_file_not_exists PASSED [100%]
-```
-
-If all tests pass, your setup is correct and you are ready to explore Canvas
-Code Correction.
-
-## What is Canvas Code Correction?
-
-**Canvas Code Correction (CCC)** is a Python‑based orchestration layer that
-automates the grading of programming assignments in Canvas. It replaces ad‑hoc
-shell scripts with a **Prefect‑powered pipeline** that:
-
-- Downloads student submissions from Canvas
-- Executes instructor‑provided grader code in **secure, ephemeral Docker
-  containers**
-- Collects scores, feedback, and artefacts
-- Uploads results back to Canvas
-
-CCC keeps **platform operators**, **grader authors**, and **contributors**
-separate:
-
-- **Platform operators** deploy and monitor the grading pipeline
-- **Grader authors** (course responsibles) create Docker images and test scripts
-- **Contributors** extend the core orchestration logic
-
-The system is **modular**, **testable**, and **secure by default**. It ships
-with MkDocs documentation, pytest‑based tests, and uv‑managed dependencies.
-
-## Documentation Structure
-
-Choose the documentation that matches your role:
-
-| Role                                   | What You Need                                       | Where to Start                                                                    |
-| -------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **Grader Author** (course responsible) | Create grader Docker images and test scripts        | [Tutorial: Create Your First Work Package in 10 Minutes](./tutorial/index.md)     |
-| **Platform Operator**                  | Deploy, configure, and monitor the grading pipeline | [Platform Setup: Configuring a Course](./platform-setup/01-configuring-course.md) |
-| **Contributor** / **Developer**        | Understand the architecture and extend the system   | [Reference: Architecture Overview](./reference/01-architecture.md)                |
-| **All Roles**                          | See what is coming next and track progress          | [Current Development: Roadmap](./current-development/01-roadmap.md)               |
-
-### Tutorial (4 files)
-
-Start here if you are a **course responsible** creating your first work package.
-
-1. **[Tutorial Index](./tutorial/index.md)** – Create a work package in 10
-   minutes
-2. **[Prerequisites](./tutorial/02-prerequisites.md)** – Canvas API access,
-   Docker basics, Python 3.13+
-3. **[Creating a Grader Docker Image](./tutorial/03-creating-grader-image.md)**
-   – Build a container with your testing environment
-4. **[Writing Grader Tests](./tutorial/04-writing-grader-tests.md)** – Write
-   scripts that evaluate student submissions
-
-### Reference (6 files)
-
-Deep dive into architecture, CLI, configuration, and APIs.
-
-1. **[Architecture Overview](./reference/01-architecture.md)** – Design goals,
-   component responsibilities, and new services
-2. **[CLI Reference](./reference/02-cli.md)** – All `ccc` commands with examples
-3. **[Configuration](./reference/03-configuration.md)** – Environment variables,
-   Prefect blocks, and course‑specific settings
-4. **[API Clients](./reference/04-api-clients.md)** – Canvas API wrapper and
-   storage client details
-5. **[Grader Image Specification](./reference/05-grader-image.md)** – Required
-   entry points, environment variables, and output format
-6. **[Authoring Grader Tests](./reference/06-authoring-grader-tests.md)** – Test
-   structure, scoring, and feedback conventions
-
-### Platform Setup (7 files)
-
-Step‑by‑step guides for **platform operators** deploying CCC in production.
-
-1. **[Configuring a Course](./platform-setup/01-configuring-course.md)** – Set
-   up a course with Canvas token, Docker image, and S3 assets
-2. **[Setting Up Prefect](./platform-setup/02-setting-up-prefect.md)** – Install
-   Prefect, create work pools, and configure agents
-3. **[Scheduling Corrections](./platform-setup/03-scheduling-corrections.md)** –
-   Create scheduled deployments and trigger flows via webhooks
-4. **[Monitoring Results](./platform-setup/04-monitoring-results.md)** – Track
-   flow runs, logs, and errors in the Prefect UI
-5. **[Deploying Tests to CCC](./platform-setup/05-deploying-tests-to-ccc.md)** –
-   Upload grader assets to S3 and link them to a course
-6. **[Prefect Agent Configuration](./platform-setup/06-prefect-agent.md)** – Run
-   a Prefect agent locally or in a container
-7. **[RustFS Storage](./platform-setup/07-rustfs-storage.md)** – Set up an
-   S3‑compatible storage backend for local development and production
-
-### Current Development (2 files)
-
-Track progress and upcoming changes.
-
-1. **[Roadmap](./current-development/01-roadmap.md)** – High‑level timeline and
-   feature priorities
-2. **[Phase 2 Migration Plan](./current-development/02-phase-2-migration-plan.md)**
-   – Detailed migration steps from v1 to v2
-
-## Quick Start
-
-Run these commands to install dependencies, run the full test suite, and serve
-the documentation locally. These commands assume **Python 3.13+** and a clean
-environment.
-
-```bash
-# Install dependencies (uv handles virtualenv and locking)
 $ uv sync
+$ source .venv/bin/activate
+$ ccc --help
 ```
 
-You will see output similar to:
+Expected output begins with:
 
+```text
+Usage: ccc [OPTIONS] COMMAND [ARGS]...
 ```
-Resolved 171 packages in 4ms
-Installed 171 packages in 2.3s
-```
+
+If that command works, your local environment is ready.
+
+## What CCC Does
+
+CCC gives you one codebase for the full grading loop:
+
+1. **Configure a course** with Canvas credentials, grader image, asset block,
+   and work pool.
+2. **Download submissions** from Canvas.
+3. **Run the grader** in Docker against a prepared workspace.
+4. **Collect results** such as points, comments, and feedback artifacts.
+5. **Upload grades and feedback** back to Canvas.
+6. **Trigger runs** manually or from Canvas webhooks through Prefect.
+
+## Choose Your Path
+
+| If you are... | Start here | Why |
+| --- | --- | --- |
+| A **course owner** writing grader logic | [Tutorial](./tutorial/index.md) | Build the grader image and grader assets. |
+| A **platform operator** running CCC | [Configuring a Course](./platform-setup/01-configuring-course.md) | Set up blocks, workers, deployments, and local services. |
+| A **developer** changing CCC itself | [Architecture Overview](./reference/01-architecture.md) | Understand the flows, services, and runtime boundaries. |
+| Tracking active work | [Roadmap](./current-development/01-roadmap.md) | See what is current, historical, or still changing. |
+
+## Documentation Map
+
+### Tutorial
+
+Use this path when you are authoring grader assets:
+
+1. [Prerequisites](./tutorial/02-prerequisites.md)
+2. [Creating a Grader Docker Image](./tutorial/03-creating-grader-image.md)
+3. [Writing Grader Tests](./tutorial/04-writing-grader-tests.md)
+
+### Platform Setup
+
+Use this path when you are operating CCC:
+
+1. [Configuring a Course](./platform-setup/01-configuring-course.md)
+2. [Setting Up Prefect](./platform-setup/02-setting-up-prefect.md)
+3. [Scheduling Corrections](./platform-setup/03-scheduling-corrections.md)
+4. [Monitoring Results](./platform-setup/04-monitoring-results.md)
+5. [Deploying Grader Tests to CCC](./platform-setup/05-deploying-tests-to-ccc.md)
+6. [Running Prefect Locally](./platform-setup/06-prefect-agent.md)
+7. [RustFS Storage](./platform-setup/07-rustfs-storage.md)
+
+### Reference
+
+Use this section when you need exact behavior or field names:
+
+1. [Architecture Overview](./reference/01-architecture.md)
+2. [CLI Reference](./reference/02-cli.md)
+3. [Configuration Reference](./reference/03-configuration.md)
+4. [API Clients](./reference/04-api-clients.md)
+5. [Grader Image Guide](./reference/05-grader-image.md)
+6. [Authoring Grader Tests](./reference/06-authoring-grader-tests.md)
+
+## Local Operator Workflow
+
+These commands cover the common local stack:
 
 ```bash
-# Run the entire test suite (~30 seconds)
-$ pytest
-```
-
-Expect a series of passing tests:
-
-```
-============================= test session starts ==============================
-platform linux -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0
-cachedir: .pytest_cache
-rootdir: /home/jsg/Documents/jsg/Canvas-Code-Correction
-configfile: pyproject.toml
-plugins: anyio-4.12.1, cov-7.0.0, datadir-1.8.0, xdist-3.8.0
-collecting ... collected 123 items
-
-tests/unit/test_workspace.py::test_workspace_config PASSED               [  0%]
-tests/unit/test_workspace.py::test_workspace_paths PASSED                [  1%]
-...
-tests/e2e/test_correction_flow.py::test_full_flow_with_mocks PASSED      [100%]
-```
-
-```bash
-# Serve documentation on http://localhost:8000
-$ poe serve-docs
-```
-
-The command starts a local MkDocs server:
-
-```
-INFO    -  Building documentation...
-INFO    -  Cleaning site directory
-INFO    -  Documentation built in 0.30 seconds
-INFO    -  [20:00:00] Serving on http://localhost:8000
-INFO    -  [20:00:00] Browser opened automatically
-```
-
-Press `Ctrl+C` to stop the server.
-
-### Local Development with RustFS
-
-For integration testing, start a local RustFS S3‑compatible server:
-
-```bash
-# Start RustFS server
+$ poe prefect
 $ poe s3
-
-# Setup RustFS for testing (creates bucket, uploads test assets)
 $ poe rustfs-setup
-
-# Run integration tests
-$ pytest -m integration
+$ ccc system status
 ```
 
-Configuration via environment variables:
+Useful development commands:
 
-- `RUSTFS_ENDPOINT`: S3 endpoint URL (default: `http://localhost:9000`)
-- `RUSTFS_ACCESS_KEY`: Access key (default: `rustfsadmin`)
-- `RUSTFS_SECRET_KEY`: Secret key (default: `rustfsadmin`)
-- `RUSTFS_BUCKET_NAME`: Bucket name (default: `test-assets`)
-- `RUSTFS_PREFIX`: Path prefix for assets (default: `dev`)
+```bash
+$ poe all
+$ uv run zensical build --strict --clean
+```
 
-## Current Status (January 2026)
+## Notes for Contributors
 
-**Phase 2 of the v2 rewrite is complete.** The following key components are
-implemented and tested:
-
-- **GraderExecutor**: Secure Docker‑based execution with resource limits and
-  timeout handling
-- **ResultCollector**: Robust parsing of grader outputs and feedback zip
-  creation
-- **CanvasUploader**: Idempotent feedback and grade uploads with duplicate
-  detection
-- **Prefect Flow Integration**: Complete end‑to‑end flow with `execute_grader`,
-  `collect_results`, `upload_feedback`, and `post_grade` tasks
-- **Enhanced CLI**: Role-based command groups for `ccc course` and `ccc system`
-- **RustFS Integration**: Configurable S3‑compatible storage backend with
-  environment‑variable support for production deployments
-- **Comprehensive Test Suite**: End‑to‑end tests with docker‑compose stack
-  (RustFS, Prefect) and GitHub Actions CI pipeline
-- **Production‑Ready Configuration**: Support for custom S3 endpoints and secure
-  credential management
-
-All unit tests pass, and the system is ready for integration testing with the
-Canvas Cloud development course.
-
-## Need Help?
-
-- Use the **agent system** described in [`AGENTS.md`](../AGENTS.md) to explore
-  the codebase and delegate tasks.
-- Check the
-  [GitHub repository](https://github.com/jakob1379/canvas-code-correction) for
-  issues and discussions.
-- Follow the
-  [Conventional Commits](../AGENTS.md#3-commit-conventions-conventional-commits)
-  convention when contributing changes.
+If you edit docs, apply [.docs-style-checklist.md](../.docs-style-checklist.md)
+to the pages you touch. Prefer runnable commands, real outputs, direct language,
+and clear links to the next page a reader should open.

--- a/docs/platform-setup/01-configuring-course.md
+++ b/docs/platform-setup/01-configuring-course.md
@@ -1,159 +1,123 @@
 # Configuring a Course
 
-**Audience**: CCC platform operators **Prerequisites**: Grader Docker image
-built, grader tests uploaded to S3 storage, Prefect blocks created
+Use `ccc course setup` to create the **course block** that CCC loads at
+runtime. This block stores the Canvas connection, grader image, asset storage
+reference, asset prefix, and Prefect work pool for one course.
 
-??? note "Try It Now (60 seconds)"
+## Try It Now
 
-    If you have a Canvas API token, course ID, and an S3 bucket block ready, run
-    this command to configure a course immediately:
-
-    ```bash
-    $ ccc course setup \
-      --slug cs101 \
-      --course-id 12345 \
-      --assets-block course-assets-cs101 \
-      --docker-image yourusername/canvas-grader:latest \
-      --s3-prefix graders/cs101/
-    ```
-
-    To avoid leaking tokens in shell history, you can pipe the token through stdin:
-
-    ```bash
-    $ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
-
-      --slug cs101 \
-      --token-stdin \
-      --course-id 12345 \
-      --assets-block course-assets-cs101 \
-      --docker-image yourusername/canvas-grader:latest \
-      --s3-prefix graders/cs101/
-    ```
-
-    You’ll see output similar to:
-
-    ```
-    Created Prefect block 'ccc-course-cs101' with:
-      Canvas course ID: 12345
-      Assets block: course-assets-cs101
-      Docker image: yourusername/canvas-grader:latest
-      S3 prefix: graders/cs101/
-    ```
-
-    The course is now ready for scheduling corrections.
-
----
-
-This guide walks you through configuring a course on the **Canvas Code
-Correction** (CCC) platform using the CLI and Prefect blocks. By the end you’ll
-have a course block that links your Canvas course to the grader image and test
-assets.
-
-## Prerequisites
-
-Before you start, gather these three items:
-
-1. **Canvas API token** – generate in your Canvas account under “Settings → New
-   Access Token”
-2. **Canvas course ID** – the numeric ID from the course URL (e.g.,
-   `https://canvas.instructure.com/courses/12345`)
-3. **Prefect S3 bucket block** – created via the Prefect UI or CLI (see
-   [Setting up Prefect](02-setting-up-prefect.md))
-
-If you haven’t built a grader image or uploaded tests yet, complete those steps
-first (see [Deploying tests to CCC](05-deploying-tests-to-ccc.md)).
-
-## Step 1: Configure a course with the CLI
-
-The `ccc course setup` command creates a Prefect block that stores all
-course‑specific settings. Run it from the project root.
-
-### Basic command
+If you already have a Canvas token, a course ID, and an assets block, run:
 
 ```bash
-$ ccc course setup \
-  --slug cs101 \
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
+  --token-stdin \
+  --api-url https://canvas.example.edu \
   --course-id 12345 \
+  --slug cs101 \
   --assets-block course-assets-cs101 \
-  --docker-image yourusername/canvas-grader:latest \
-  --s3-prefix graders/cs101/
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101
 ```
 
-**What each option does:**
+Expected output includes:
 
-| Option                 | Description                                                              |
-| ---------------------- | ------------------------------------------------------------------------ |
-| `cs101`                | **Course slug** – a short, URL‑safe identifier (used in block names)     |
-| `--token`, `-t`        | Canvas API token (if omitted, you’ll be prompted)                        |
-| `--course-id`, `-i`    | Numeric Canvas course ID                                                 |
-| `--assets-block`, `-a` | Name of an existing Prefect S3 bucket block                              |
-| `--docker-image`, `-d` | Docker image that runs the grader (defaults to the base image)           |
-| `--s3-prefix`, `-p`    | Path prefix inside the S3 bucket where grader assets are stored          |
-| `--env`, `-e`          | Environment variables for the grader container (`KEY=VALUE`, repeatable) |
-
-### Expected output
-
-After a successful run you’ll see:
-
-```
-Created Prefect block 'ccc-course-cs101' with:
-  Canvas course ID: 12345
-  Assets block: course-assets-cs101
-  Docker image: yourusername/canvas-grader:latest
-  S3 prefix: graders/cs101/
+```text
+✓ Canvas access validated successfully
+✓ Course ID 12345 validated
+✓ Course configuration saved as block: ccc-course-cs101
 ```
 
-The block is now stored in your Prefect workspace and can be referenced by its
-slug (`cs101`).
+## What You Need
 
-## Step 2: Understanding Prefect blocks
+Before you run the command, gather:
 
-CCC uses **Prefect blocks** to store configuration securely. The command creates
-a block named `ccc-course-<slug>` (e.g., `ccc-course-cs101`). The block
-contains:
+1. A **Canvas API token**
+2. The numeric **Canvas course ID**
+3. An **assets block** that points at S3-compatible storage
+4. A **grader Docker image**
+5. A **work pool name** for Prefect workers
 
-- Canvas token (encrypted)
-- Course ID
-- S3 bucket block reference
-- Docker image name
-- S3 prefix
-- Any environment variables
+If you still need the assets block, start with
+[RustFS Storage](07-rustfs-storage.md) for local development or your production
+S3-compatible setup.
 
-**Important**: The S3 bucket block must exist before you run `course setup`.
-Create it via the Prefect UI or CLI (see
-[Setting up Prefect](02-setting-up-prefect.md)).
+## The Command
 
-## Step 3: Verify the configuration
+`ccc course setup` is interactive by default. For repeatable automation, use
+`--no-interactive` and pass every required value.
 
-List all configured courses to confirm your block was created:
+```bash
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
+  --token-stdin \
+  --api-url https://canvas.example.edu \
+  --course-id 12345 \
+  --slug cs101 \
+  --assets-block course-assets-cs101 \
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101 \
+  --env PYTHONUNBUFFERED=1
+```
+
+### Important flags
+
+| Flag | What it controls |
+| --- | --- |
+| `--token-stdin` | Reads the Canvas token from standard input. |
+| `--api-url`, `-u` | Canvas base URL. |
+| `--course-id`, `-c` | Canvas course to bind to the block. |
+| `--slug` | Suffix used in the block name `ccc-course-<slug>`. |
+| `--assets-block` | Prefect block name for S3-compatible storage. |
+| `--assets-prefix` | Prefix inside the assets bucket, for example `graders/cs101/`. |
+| `--docker-image`, `-d` | Grader image used for corrections. |
+| `--work-pool` | Prefect work pool that should execute this course. |
+| `--env`, `-e` | Extra grader environment variables, repeatable. |
+
+## What CCC Saves
+
+The resulting `ccc-course-<slug>` block contains:
+
+- **Canvas** URL, token, and course ID
+- **Assets** block name and prefix
+- **Grader** image, work pool, and extra environment variables
+- **Webhook** defaults such as deployment name and rate limit
+
+For the exact runtime model, see
+[Configuration Reference](../reference/03-configuration.md).
+
+## Verify the Block
+
+List the configured courses:
 
 ```bash
 $ ccc course list
 ```
 
-Output:
+Expected result: a table that includes the block name, Canvas course ID, grader
+image, and assets block.
 
+## Common Errors
+
+Missing token in non-interactive mode:
+
+```bash
+$ ccc course setup --no-interactive --course-id 12345 --assets-block course-assets-cs101
 ```
-Slug    Canvas ID  Docker Image
-cs101   12345      yourusername/canvas-grader:latest
+
+Expected output:
+
+```text
+--token or --token-stdin is required in non-interactive mode
 ```
 
-If you see your course in the list, the configuration is ready.
+If Canvas validation fails, re-check the base URL and token. The CLI will print
+the attempted URL and common causes.
 
-## Next steps
+## Next Steps
 
-With a course configured, you can:
+After the course block exists:
 
-1. **Set up Prefect deployments and workers** –
-   [Setting up Prefect](02-setting-up-prefect.md)
-2. **Schedule automatic corrections** –
-   [Scheduling corrections](03-scheduling-corrections.md)
-3. **Monitor results** – [Monitoring results](04-monitoring-results.md)
-4. **Deploy updated tests** –
-   [Deploying tests to CCC](05-deploying-tests-to-ccc.md)
-
-!!! note
-
-    The course block is now available to any Prefect flow that uses the
-    `Course` block type. You can update its settings by running `course setup`
-    again with the same slug.
+1. [Set up Prefect](02-setting-up-prefect.md)
+2. [Deploy grader assets to CCC](05-deploying-tests-to-ccc.md)
+3. [Run or monitor corrections](04-monitoring-results.md)

--- a/docs/platform-setup/02-setting-up-prefect.md
+++ b/docs/platform-setup/02-setting-up-prefect.md
@@ -1,174 +1,139 @@
-# Setting up Prefect
+# Setting Up Prefect
 
-!!! note "Audience" CCC platform operators **Prerequisites**: Course configured
-via `ccc course setup` (see [Configuring a Course](01-configuring-course.md))
+CCC stores course blocks in **Prefect**, creates webhook-oriented deployments
+through **`ccc system deploy create`**, and executes those deployments with
+**workers** attached to a work pool.
 
-**Prefect** orchestrates the correction workflows in CCC. After you configure a
-course, you need to create a **Prefect deployment** (the definition of how to
-run your flow) and start a **worker** (the process that executes flow runs).
-This guide walks you through both steps in **3 minutes**.
+## Try It Now
 
-!!! note "Try It Now (90 seconds)"
-
-    If you already have a course configured with slug `cs101`, run these two
-    commands to create a deployment and start a worker:
-
-    ```bash
-    $ prefect deployment build \
-      canvas_code_correction.flows.correct_submission:correct_submission_flow \
-      -n cs101-corrections \
-      -q course-work-pool-cs101 \
-      -a
-    ```
-
-    Expected output:
-
-    ```
-    Successfully created deployment 'cs101-corrections'!
-    Deployment applied to work pool 'course-work-pool-cs101'.
-    ```
-
-    Then start the worker:
-
-    ```bash
-    $ prefect worker start --pool course-work-pool-cs101
-    ```
-
-    You’ll see the worker connect to Prefect and wait for flow runs. Keep this
-    terminal open.
-
----
-
-## Prerequisites
-
-- A course configured with `ccc course setup` (if you haven’t, complete
-  [Configuring a Course](01-configuring-course.md) first)
-- The same Python environment where you installed CCC (`uv run` works)
-- Docker installed and running (the worker will launch grader containers)
-
-## Step 1: Create a Prefect deployment
-
-A **deployment** makes your correction flow triggerable via schedule, API, or
-UI. Use the Prefect CLI with your course’s **work pool name** (default
-`course-work-pool-<slug>`).
-
-### Command template
+For a course block named `ccc-course-cs101`, this is the shortest local setup:
 
 ```bash
-$ prefect deployment build \
-  canvas_code_correction.flows.correct_submission:correct_submission_flow \
-  -n <deployment-name> \
-  -q <work-pool-name> \
-  -a
+$ poe prefect
 ```
 
-Replace `<deployment-name>` with a unique identifier (e.g., `cs101-corrections`)
-and `<work-pool-name>` with the pool your worker will listen to (e.g.,
-`course-work-pool-cs101`).
-
-### Example with course slug `cs101`
+In a second terminal:
 
 ```bash
-$ prefect deployment build \
-  canvas_code_correction.flows.correct_submission:correct_submission_flow \
-  -n cs101-corrections \
-  -q course-work-pool-cs101 \
-  -a
+$ uv run prefect work-pool create --type process course-work-pool-cs101
+$ ccc system deploy create ccc-course-cs101
+$ uv run prefect worker start --pool course-work-pool-cs101
 ```
 
-**What each flag does:**
+Expected deployment output includes:
 
-| Flag | Purpose                                                                 |
-| ---- | ----------------------------------------------------------------------- |
-| `-n` | **Deployment name** – unique identifier (used when triggering runs)     |
-| `-q` | **Work pool** – must match the pool your worker subscribes to           |
-| `-a` | **Apply** – create the deployment in your Prefect workspace immediately |
-
-After a successful run you’ll see:
-
-```
-Successfully created deployment 'cs101-corrections'!
-Deployment applied to work pool 'course-work-pool-cs101'.
+```text
+Creating deployment for course block: ccc-course-cs101
+Deployment 'ccc-cs101-deployment' created/updated successfully
 ```
 
-The deployment is now visible in the Prefect UI under **Deployments**.
+## Step 1: Start the Prefect API
 
-## Step 2: Start a worker
-
-**Workers** are processes that pick up flow runs from a work pool and execute
-them. Start a worker for your course’s work pool in a separate terminal (or
-background process).
-
-### Command
+For local development, run:
 
 ```bash
-$ prefect worker start --pool course-work-pool-cs101
+$ poe prefect
 ```
 
-### Expected output
+This starts the Prefect UI and API at `http://localhost:4200`.
 
+If you use a remote Prefect environment, set `PREFECT_API_URL` and
+`PREFECT_API_KEY` accordingly before running CCC commands.
+
+## Step 2: Create the Work Pool
+
+The course block stores a `work_pool_name`. Create that pool before starting a
+worker.
+
+```bash
+$ uv run prefect work-pool create --type process course-work-pool-cs101
 ```
+
+You only need to do this once per pool name.
+
+## Step 3: Create the Deployment
+
+CCC owns the deployment shape for webhook-triggered corrections. Do not build
+it manually with `prefect deployment build`; use the CLI wrapper instead.
+
+```bash
+$ ccc system deploy create ccc-course-cs101
+```
+
+The default deployment name for that block is:
+
+```text
+webhook-correction-flow/ccc-cs101-deployment
+```
+
+If you set a custom deployment name in the course block, CCC will use that
+instead.
+
+## Step 4: Start a Worker
+
+Start a worker subscribed to the same pool as the course block:
+
+```bash
+$ uv run prefect worker start --pool course-work-pool-cs101
+```
+
+Expected output begins with:
+
+```text
 Starting worker for pool 'course-work-pool-cs101'...
-Worker 'eager-panda' started!
-Waiting for flow runs...
 ```
 
-The worker will stay alive and wait for flow runs. It must have:
+The worker host must have:
 
-- **Access to Docker** (to launch grader containers)
-- **The same environment variables** (Canvas token, etc.) that you configured in
-  the course block
-- **Network connectivity** to Prefect API (cloud or local server)
+- Docker access
+- Network access to the Prefect API
+- Any registry credentials needed to pull the grader image
 
-You can run workers on any machine: your laptop, a server, or a container
-orchestration platform. Multiple workers can join the same pool for load
-distribution.
+## Step 5: Verify the Stack
 
-## Step 3: Trigger a test run
-
-With a deployment created and a worker running, trigger a correction flow to
-verify everything works.
-
-### Option A: Prefect UI
-
-1. Open the Prefect UI (cloud or local).
-2. Navigate to **Deployments** and find your deployment (`cs101-corrections`).
-3. Click the **Run** button.
-
-### Option B: Prefect CLI
+Run the local health check:
 
 ```bash
-$ prefect deployment run cs101-corrections
+$ ccc system status
 ```
 
-Output:
+Expected output contains health lines for:
 
-```
-Flow run 'golden-sloth' created!
-```
+- `Prefect server`
+- `RustFS (S3)` when credentials are configured
 
-### Option C: CCC CLI (for a specific assignment)
+Then trigger a small manual run:
 
 ```bash
-$ ccc course run <assignment-id>
+$ ccc course run 98765 --course ccc-course-cs101 --submission-id 54321 --dry-run
 ```
 
-Replace `<assignment-id>` with the numeric Canvas assignment ID. This command
-creates a one‑off flow run for a single assignment, ideal for testing.
+That verifies the course block loads and the flow can execute without posting
+results.
 
-**Test with a single submission first** to ensure the worker can pull the grader
-image, fetch tests from S3, and submit scores back to Canvas.
+## Troubleshooting
 
-## Next steps
+### The deployment command fails
 
-Your Prefect deployment and worker are now ready. Next, you can:
+- Confirm `PREFECT_API_URL` points at a reachable Prefect API.
+- Confirm the course block exists with `ccc course list`.
 
-- **Schedule automatic corrections** – attach a cron schedule to the deployment
-  ([Scheduling corrections](03-scheduling-corrections.md))
-- **Monitor runs and logs** – use the Prefect UI to inspect flow runs
-  ([Monitoring results](04-monitoring-results.md))
-- **Scale workers** – add more workers to the same pool for higher throughput
+### The worker stays idle
 
-!!! tip
-    Keep the worker terminal open while testing. For production, run workers as systemd services or
-    containerized processes.
+- Confirm the worker pool name matches the course block.
+- Inspect the deployment in Prefect:
+
+  ```bash
+  $ uv run prefect deployment inspect webhook-correction-flow/ccc-cs101-deployment
+  ```
+
+### The worker cannot pull the grader image
+
+- Test Docker locally with `docker pull <image>`.
+- Add registry credentials to the worker environment if the image is private.
+
+## Next Steps
+
+- [Scheduling Corrections](03-scheduling-corrections.md)
+- [Monitoring Results](04-monitoring-results.md)
+- [Running Prefect Locally](06-prefect-agent.md)

--- a/docs/platform-setup/03-scheduling-corrections.md
+++ b/docs/platform-setup/03-scheduling-corrections.md
@@ -1,212 +1,93 @@
 # Scheduling Corrections
 
-!!! note "Audience"
-    CCC platform operators **Prerequisites**: Prefect deployment created and worker running (see
-    [Setting up Prefect](02-setting-up-prefect.md))
+This page aligns with the **current CCC deployment model**:
 
-## Try It Now (60 seconds)
+- `ccc system deploy create` creates a **webhook-oriented deployment**
+- `ccc course run` is the supported path for **manual and backfill runs**
+- Canvas webhooks are the supported path for **automatic per-submission runs**
 
-Schedule automatic corrections for a course that already has a Prefect
-deployment. If you have a deployment named `cs101-corrections`, attach a cron
-schedule that runs daily at 2 AM:
+## What "Scheduling" Means Today
 
-```bash
-$ prefect deployment build \
-  canvas_code_correction.flows.correct_submission:correct_submission_flow \
-  -n cs101-corrections \
-  -q course-work-pool-cs101 \
-  --schedule "0 2 * * *" \
-  -a
-```
+CCC does **not** ship a built-in cron-style batch deployment for "grade every
+submission in a course at 02:00 every day". The deployment created by
+`ccc system deploy create` expects webhook-style course and submission payloads,
+so it is intended for **event-driven runs**, not parameterless nightly sweeps.
 
-Expected output:
+## Recommended Automation Patterns
 
-```
-Successfully updated deployment 'cs101-corrections'!
-Deployment applied to work pool 'course-work-pool-cs101'.
-```
+### 1. Immediate grading on submission
 
-Your corrections now run automatically every day at 2 AM. Continue with the
-guide to learn cron syntax, webhook triggers, and manual overrides.
+Use this when you want the normal production flow.
 
----
+1. Start the webhook server:
 
-**Canvas Code Correction** runs submissions on a schedule (e.g., every night at
-2 AM) or triggers immediately via Canvas webhooks when a student submits. This
-guide walks you through both options in **5 minutes**.
+   ```bash
+   $ ccc system webhook serve --host 0.0.0.0 --port 8080
+   ```
 
-## Prerequisites
+2. Create the Prefect deployment:
 
-Before you schedule corrections, ensure you have:
+   ```bash
+   $ ccc system deploy create ccc-course-cs101
+   ```
 
-1. **A Prefect deployment** – created with `prefect deployment build`
-   ([Setting up Prefect](02-setting-up-prefect.md))
-2. **A running worker** – listening to the same work pool as the deployment
-3. **Access to the Canvas course** – to set up webhooks (optional)
+3. Start a worker for the course work pool:
 
-If you haven’t completed the setup, go back to
-[Setting up Prefect](02-setting-up-prefect.md) and finish **Steps 1 and 2**.
+   ```bash
+   $ uv run prefect worker start --pool course-work-pool-cs101
+   ```
 
-## 1. Scheduling with Cron
+4. Configure Canvas to send submission events to the webhook server.
 
-**Prefect schedules** let you run corrections at fixed times (like a system cron
-job). Attach the schedule when you build or update a deployment.
+### 2. Manual backfills
 
-### Cron syntax quick reference
-
-CCC uses standard cron syntax with five fields:
-
-```
-┌───────────── minute (0–59)
-│ ┌───────────── hour (0–23)
-│ │ ┌───────────── day of month (1–31)
-│ │ │ ┌───────────── month (1–12)
-│ │ │ │ ┌───────────── day of week (0–6, Sunday=0)
-│ │ │ │ │
-│ │ │ │ │
-* * * * *
-```
-
-| Example         | Meaning                             |
-| --------------- | ----------------------------------- |
-| `0 2 * * *`     | Every day at 02:00                  |
-| `30 14 * * 1-5` | Monday–Friday at 14:30              |
-| `*/15 * * * *`  | Every 15 minutes                    |
-| `0 0 1 * *`     | First day of each month at midnight |
-
-### Attach a schedule to an existing deployment
-
-Use the same `prefect deployment build` command with the `--schedule` flag.
-**Keep all other flags identical** (name, work pool, etc.).
+Use this when you need to rerun an assignment or a single submission.
 
 ```bash
-$ prefect deployment build \
-  canvas_code_correction.flows.correct_submission:correct_submission_flow \
-  -n cs101-corrections \
-  -q course-work-pool-cs101 \
-  --schedule "0 2 * * *" \
-  -a
+$ ccc course run 98765 --course ccc-course-cs101
 ```
 
-**What happens:**
-
-- The existing deployment `cs101-corrections` updates with the new schedule.
-- Future flow runs create automatically at the specified times.
-- The worker picks up each run and executes the correction flow.
-
-!!! tip
-    To remove a schedule, run the same command **without** the `--schedule` flag.
-
-### View and edit schedules in the Prefect UI
-
-1. Open the Prefect UI (cloud or local).
-2. Navigate to **Deployments** and select your deployment.
-3. Click the **Schedule** tab to see the cron expression and next scheduled run.
-4. Use the **Edit** button to change the schedule interactively.
-
-## 2. Trigger via Canvas Webhooks
-
-For immediate corrections after each student submission, configure Canvas to
-send webhooks to your Prefect deployment.
-
-### How webhooks work
-
-1. Canvas detects a `submission_created` event.
-2. Canvas sends an HTTP POST to a **webhook endpoint** provided by Prefect.
-3. Prefect creates a flow run for the affected assignment and submission.
-4. Your worker picks up the run and corrects that submission.
-
-### Step‑by‑step setup
-
-#### 1. Get your deployment’s webhook URL
-
-Prefect Cloud automatically provides a webhook endpoint for each deployment.
-
-1. In the Prefect UI, go to **Deployments** and select your deployment.
-2. Click the **Webhooks** tab.
-3. Copy the **URL** shown (looks like
-   `https://api.prefect.cloud/api/accounts/.../webhooks/...`).
-
-!!! note
-    If you run a self‑hosted Prefect server, consult the [Prefect webhook documentation](https://docs.prefect.io/concepts/webhooks/) for
-    endpoint configuration.
-
-#### 2. Add the webhook in Canvas
-
-1. In Canvas, go to your course → **Settings** → **Integrations**.
-2. Click **+ Add Webhook**.
-3. Fill in the fields:
-
-   | Field      | Value                               |
-   | ---------- | ----------------------------------- |
-   | **URL**    | Paste the webhook URL from Prefect  |
-   | **Event**  | Select `submission_created`         |
-   | **Format** | `JSON` (default)                    |
-   | **Secret** | (Optional) Add a secret for signing |
-
-4. Click **Save**.
-
-Canvas now sends a POST request to Prefect for every new submission.
-
-#### 3. Verify the webhook payload
-
-CCC expects a JSON payload with at least `assignment_id` and `submission_id`.
-Canvas sends a richer object; CCC extracts the required fields automatically.
-
-To transform the payload (e.g., rename keys), write a small middleware or use
-Prefect’s **webhook transformations** (see
-[Prefect webhook documentation](https://docs.prefect.io/concepts/webhooks/)).
-
-### Test the webhook
-
-1. Make a test submission in Canvas.
-2. Watch the Prefect UI for a new flow run (appears within seconds).
-3. Check the logs to confirm the correction succeeded.
-
-## 3. Manual Triggers (When You Need Control)
-
-Even with schedules and webhooks, you can always trigger corrections manually.
-
-### Via the Prefect UI
-
-1. Open **Deployments** and select your deployment.
-2. Click the **Run** button.
-3. Choose **Custom** to provide parameters (assignment ID, submission ID, etc.).
-
-### Via the CLI
+Or:
 
 ```bash
-$ prefect deployment run cs101-corrections
+$ ccc course run 98765 --course ccc-course-cs101 --submission-id 54321 --dry-run
 ```
 
-This creates a flow run for **all submissions that need grading** (default
-behavior).
+### 3. Custom scheduled jobs
 
-### Via the CCC CLI (single assignment)
+If your team needs nightly or weekly backfills, create a **separate Prefect
+flow** that calls CCC with the assignment IDs you want. That scheduled flow is
+outside the built-in webhook deployment that CCC creates for you.
+
+## Prefect Deployment Schedules
+
+Prefect itself supports deployment schedules:
 
 ```bash
-$ ccc course run 12345
+$ uv run prefect deployment schedule create --help
 ```
 
-Replace `12345` with the numeric Canvas assignment ID. This command creates a
-one‑off flow run for just that assignment, ideal for debugging or urgent
-corrections.
+Use those commands only for deployments whose parameters make sense on a
+schedule. For the built-in CCC webhook deployment, that usually means **do not**
+attach a cron schedule unless you have wrapped it with the required inputs.
 
-## 4. Monitoring and Next Steps
+Useful commands:
 
-Once corrections are scheduled, use the **Prefect dashboard** to monitor flow
-runs, view logs, and inspect results. For a full guide, see
-[Monitoring results](04-monitoring-results.md).
+```bash
+$ uv run prefect deployment schedule ls <FLOW_NAME>/<DEPLOYMENT_NAME>
+$ uv run prefect deployment schedule clear <FLOW_NAME>/<DEPLOYMENT_NAME> --accept-yes
+```
 
-### Quick checklist after setup
+## Canvas Webhook Checklist
 
-- [ ] Schedule attached (cron expression correct)
-- [ ] Worker online and listening to the work pool
-- [ ] Webhook configured (if using immediate triggers)
-- [ ] Test run completed successfully
+For the standard automatic path, confirm:
 
----
+- the webhook server is reachable
+- the Prefect deployment exists
+- a worker is online for the course work pool
+- the course block points at the correct work pool and assets
 
-**Next**: Learn how to interpret correction results, view feedback in Canvas,
-and troubleshoot common issues in
-[Monitoring results](04-monitoring-results.md).
+## Next Steps
+
+Once runs are being triggered, continue with
+[Monitoring Results](04-monitoring-results.md).

--- a/docs/platform-setup/04-monitoring-results.md
+++ b/docs/platform-setup/04-monitoring-results.md
@@ -1,301 +1,128 @@
 # Monitoring Results
 
-!!! note "Audience"
-    CCC platform operators **Prerequisites**: Corrections running via Prefect (see [Scheduling
-    corrections](03-scheduling-corrections.md))
+Use **Prefect** to monitor runs and **Canvas** to verify the uploaded grade and
+feedback.
 
-**CCC** uploads feedback and grades to Canvas after each correction run. You can
-monitor the entire process through the **Prefect dashboard** and verify the
-results in **Canvas**. This guide walks you through both in **3 minutes**.
+## Try It Now
 
-!!! note "Try It Now (60 seconds)"
-
-    If you have a correction flow that ran in the last hour, open the Prefect UI
-    and check its status:
-
-    ```bash
-    $ prefect server start  # if using local server
-    # Or open https://app.prefect.cloud/your-workspace
-    ```
-
-    Then list the most recent flow runs for your deployment:
-
-    ```bash
-    $ prefect flow-run ls --limit 5
-    ```
-
-    Expected output (example):
-
-    ```
-    ID                                    Name                State    Start Time
-    ─────────────────────────────────────────────────────────────────────────────
-    2a1b3c4d-5e6f-7890-abcd-ef1234567890  cs101-corrections   Success  2025-01-21 14:30:00
-    1b2c3d4e-5f6g-7890-bcde-fg2345678901  cs101-corrections   Failed   2025-01-21 14:25:00
-    ```
-
-    **Success** means the correction completed and feedback was uploaded to
-    Canvas. **Failed** indicates an error: see the troubleshooting section below.
-
----
-
-## Prerequisites
-
-Before you start monitoring, ensure:
-
-1. **Corrections are scheduled or triggered** – either via cron schedule,
-   webhook, or manual run
-   ([Scheduling corrections](03-scheduling-corrections.md))
-2. **Prefect worker is running** – listening to the same pool as your deployment
-   ([Setting up Prefect](02-setting-up-prefect.md))
-3. **Canvas course access** – you can log into the Canvas course as an
-   instructor to view feedback
-
-If you haven’t run any corrections yet, trigger a test run with:
+List the most recent flow runs:
 
 ```bash
-$ ccc course run <assignment-id>
+$ uv run prefect flow-run ls --limit 5
 ```
 
-Replace `<assignment-id>` with a numeric Canvas assignment ID. Wait 2–3 minutes
-for the flow to complete.
-
-## 1. Monitoring with Prefect Dashboard
-
-The **Prefect UI** gives you real‑time visibility into flow runs, logs, and
-errors. Use it to verify that corrections are running, inspect grader output,
-and debug failures.
-
-### Open the dashboard
-
-- **Prefect Cloud**: Go to `https://app.prefect.cloud/your-workspace`
-- **Local Prefect server**: Start the UI with `prefect server start` and open
-  `http://localhost:4200`
-
-### Check flow‑run status
-
-From the CLI, list recent flow runs for your deployment:
+Then inspect one run's logs:
 
 ```bash
-$ prefect flow-run ls --limit 10
+$ uv run prefect flow-run logs <flow-run-id> --tail
 ```
 
-**Expected output** (columns may vary):
-
-```
-ID                                    Name                State    Start Time
-─────────────────────────────────────────────────────────────────────────────
-2a1b3c4d-5e6f-7890-abcd-ef1234567890  cs101-corrections   Success  2025-01-21 14:30:00
-1b2c3d4e-5f6g-7890-bcde-fg2345678901  cs101-corrections   Failed   2025-01-21 14:25:00
-```
-
-**States to watch**:
-
-- **`Success`** – correction completed; feedback uploaded to Canvas
-- **`Failed`** – something went wrong; check the logs
-- **`Pending`** – waiting for a worker
-- **`Running`** – currently executing
-
-### View logs and task output
-
-Click a flow run in the UI, or use the CLI to stream its logs:
+For the local stack, also run:
 
 ```bash
-$ prefect flow-run logs <flow-run-id>
+$ ccc system status
 ```
 
-The logs show each step of the correction process:
+## Prefect Checks
 
-1. **Fetch submission** – downloading student files from Canvas
-2. **Pull grader image** – Docker image for your grader
-3. **Run grader** – executing the grader container with the student’s code
-4. **Upload feedback** – packaging results and posting to Canvas
-
-**Look for**:
-
-- `Grader output:` lines – the raw stdout/stderr from your grader container
-- `Uploaded feedback ZIP to Canvas` – confirmation that feedback reached Canvas
-- Any **error messages** (Docker failures, missing files, Canvas API errors)
-
-## 2. Viewing Canvas Feedback
-
-CCC uploads a **feedback ZIP file** to each submission’s comments area. Students
-can download the ZIP from their submission page; instructors can see it in
-SpeedGrader.
-
-### Locate the feedback ZIP
-
-1. Go to the Canvas assignment.
-2. Click **SpeedGrader**.
-3. Select a student’s submission.
-4. In the right‑hand comments panel, look for a file attachment named
-   `feedback-<timestamp>.zip`.
-
-### What’s inside the ZIP
-
-Download and extract the ZIP to see three files:
-
-| File               | Purpose                                        |
-| ------------------ | ---------------------------------------------- |
-| **`results.json`** | Structured results from the grader (JSON)      |
-| **`comments.txt`** | Plain‑text feedback for the student            |
-| **`points.txt`**   | Score(s) – the first line is the numeric grade |
-
-**Example `comments.txt`**:
-
-```
-Your submission passed 3/5 test cases.
-
-✓ test_addition passed
-✓ test_subtraction passed
-✗ test_multiplication failed (expected 6, got 7)
-✗ test_division failed (division by zero)
-✓ test_modulus passed
-
-See results.json for detailed output.
-```
-
-**Example `points.txt`**:
-
-```
-3
-```
-
-## 3. Verifying Grades
-
-CCC can post grades to Canvas automatically if **grade posting** is enabled in
-your course configuration. The grade is extracted from the first line of
-`points.txt`.
-
-### How grades are posted
-
-1. The grader container writes a numeric score to `points.txt` (one number per
-   line).
-2. CCC reads the first line and submits it as the submission’s grade.
-3. The grade appears in the Canvas gradebook.
-
-**Important**: The grader must output a numeric value (e.g., `5`, `87.5`).
-Non‑numeric lines are ignored.
-
-### Check the gradebook
-
-Open the Canvas gradebook for the assignment. You should see grades for
-submissions that have been corrected. If a grade is missing:
-
-- Confirm the grader wrote a valid number to `points.txt`
-- Ensure **grade posting** is enabled (see
-  [Configuring a Course](01-configuring-course.md))
-- Look for errors in the Prefect logs (`Upload grade failed`)
-
-## 4. Troubleshooting Common Issues
-
-Use this step‑by‑step checklist to diagnose problems.
-
-### Issue 1: Grader container fails
-
-**Symptoms**: Flow run fails with `Docker container exited with code 1`, or logs
-show `Grader output:` contains a stack trace.
-
-**Diagnosis**:
-
-1. Run the grader image locally with a test submission:
-   ```bash
-   $ docker run --rm yourusername/canvas-grader:latest /path/to/student/code
-   ```
-2. Check dependencies and entrypoint in your Dockerfile.
-
-**Fix**: Update the Docker image, rebuild, and push. Then reconfigure the course
-with the new image tag:
+### List recent flow runs
 
 ```bash
-$ ccc course setup --slug cs101 --docker-image yourusername/canvas-grader:v2
+$ uv run prefect flow-run ls --limit 10
 ```
 
-### Issue 2: Missing submission files
+Useful states:
 
-**Symptoms**: Logs show `No files found for submission` or
-`Canvas API returned empty file list`.
+- `Running`
+- `Completed`
+- `Failed`
+- `Pending`
 
-**Diagnosis**:
-
-1. Verify the Canvas token and course ID are correct:
-   ```bash
-   $ ccc course list
-   ```
-2. Ensure the assignment ID exists and students have submitted files.
-
-**Fix**: Regenerate the Canvas token and update the course block:
+### Read the logs
 
 ```bash
-$ printf "%s" "$NEW_TOKEN" | ccc course setup --slug cs101 --token-stdin
+$ uv run prefect flow-run logs <flow-run-id>
 ```
 
-### Issue 3: S3 asset fetch fails
+Look for the major correction stages:
 
-**Symptoms**: `Failed to fetch assets from S3` or `No such key` errors.
+1. submission metadata fetch
+2. workspace preparation
+3. grader execution
+4. feedback upload
+5. grade upload
 
-**Diagnosis**:
-
-1. Confirm the S3 bucket block exists and the worker has read permissions.
-2. Check the S3 prefix matches where you uploaded grader tests
-   ([Deploying tests to CCC](05-deploying-tests-to-ccc.md)).
-
-**Fix**: Update the course block with the correct prefix or recreate the S3
-bucket block.
-
-### Issue 4: Prefect worker offline
-
-**Symptoms**: Flow runs stuck in `Pending` state for more than 5 minutes.
-
-**Diagnosis**:
-
-1. List active workers:
-   ```bash
-   $ prefect worker ls
-   ```
-2. Ensure a worker is running for your work pool (`course-work-pool-cs101`).
-
-**Fix**: Start the worker (keep the terminal open or run as a service):
+### Inspect the deployment
 
 ```bash
-$ prefect worker start --pool course-work-pool-cs101
+$ uv run prefect deployment inspect webhook-correction-flow/ccc-cs101-deployment
 ```
 
-### Issue 5: Feedback not appearing in Canvas
+This is the fastest way to confirm the deployment name, work pool, and
+parameters in Prefect.
 
-**Symptoms**: Flow run succeeds but no ZIP appears in SpeedGrader.
-
-**Diagnosis**:
-
-1. Check the logs for `Uploaded feedback ZIP to Canvas` – if missing, Canvas API
-   may have rejected the upload.
-2. Verify the Canvas token has **write** permissions (`courses:grades:edit`,
-   `courses:assignments:edit`).
-
-**Fix**: Regenerate the token with the correct scopes and update the course
-block.
-
-### Debugging with a single submission
-
-When in doubt, run a one‑off correction for a specific submission to see
-detailed output:
+### Inspect the work pool
 
 ```bash
-$ ccc course run <assignment-id> --submission-id <submission-id>
+$ uv run prefect work-pool inspect course-work-pool-cs101
 ```
 
-The command prints each step and stops on the first error.
+Use this when runs stay pending and you need to confirm the pool exists and is
+not paused.
 
-## Next Steps
+## Canvas Checks
 
-Your correction pipeline is now fully observable. Next, you can:
+After a successful run, verify the submission in Canvas:
 
-- **Iterate on grader tests** – improve feedback quality and test coverage
-  ([Deploying tests to CCC](05-deploying-tests-to-ccc.md))
-- **Scale workers** – add more workers to handle concurrent submissions
-- **Set up alerts** – configure Prefect notifications for failed flow runs
-- **Review advanced topics** – see the Administration and Development sections
-  for custom integrations
+1. Open the assignment in **SpeedGrader**
+2. Select the submission
+3. Confirm the score changed if grade uploads are enabled
+4. Confirm the feedback attachment or comment is present
 
-!!! tip
-    Keep the Prefect UI open during peak submission periods to catch failures early. Use the
-    troubleshooting checklist above to resolve common issues in 2–5 minutes.
+CCC typically uploads:
+
+- a score from `points.txt`
+- a comment from `comments.txt`
+- feedback artifacts when the grader produced them
+
+## Common Failure Modes
+
+### Runs stay pending
+
+- Start or restart a worker:
+
+  ```bash
+  $ uv run prefect worker start --pool course-work-pool-cs101
+  ```
+
+- Confirm the course block and worker use the same pool name.
+
+### RustFS or S3 access fails
+
+- Recheck the block and prefix stored in the course block.
+- Run the local probe:
+
+  ```bash
+  $ ccc system status
+  ```
+
+### The grader image fails to start
+
+- Test the image outside CCC:
+
+  ```bash
+  $ docker run --rm <image:tag> --help
+  ```
+
+- Confirm the worker host can pull the image.
+
+### Canvas uploads fail
+
+- Re-run `ccc course setup` if the token changed.
+- Confirm the course ID and token still match the target Canvas environment.
+
+## Related Docs
+
+- [Setting Up Prefect](02-setting-up-prefect.md)
+- [Deploying Grader Tests to CCC](05-deploying-tests-to-ccc.md)
+- [Configuration Reference](../reference/03-configuration.md)

--- a/docs/platform-setup/05-deploying-tests-to-ccc.md
+++ b/docs/platform-setup/05-deploying-tests-to-ccc.md
@@ -1,375 +1,151 @@
-# Deploying Grader Tests to Canvas Code Correction (CCC)
+# Deploying Grader Tests to CCC
 
-!!! note "Try It Now (5 minutes)"
+This guide covers the **current integration contract** between grader assets and
+CCC:
 
-    Deploy your first grader test to CCC using local RustFS storage. This quick
-    start assumes you have:
+- your **Docker image** provides the grading runtime
+- your **assets block + assets prefix** point at grader files in S3-compatible storage
+- the course block ties those together with Canvas and Prefect settings
 
-    - Docker installed and running
-    - `uv` installed (see [project setup](../../README.md))
-    - Prefect Cloud or self-hosted Orion configured
-      ([Setting up Prefect](02-setting-up-prefect.md))
-    - Canvas API token and course ID stored in `.env` or Prefect blocks
+## Try It Now
 
-    **Start the local S3 server**:
-
-    ```bash
-    $ poe s3
-    ```
-
-    ```
-    Starting RustFS server on http://localhost:9000
-    Access key: rustfsadmin
-    Secret key: rustfsadmin
-    Storage directory: ./workspace
-    Server ready.
-    ```
-
-    **In a new terminal, set up RustFS for CCC**:
-
-    ```bash
-    $ poe rustfs-setup
-    ```
-
-    ```
-    ✓ RustFS server reachable at http://localhost:9000
-    ✓ Bucket 'test-assets' created
-    ✓ Test asset uploaded to s3://test-assets/dev/test.txt
-    ✓ Prefect S3 block 'local-rustfs' registered
-    Local RustFS is ready for use with CCC.
-    ```
-
-    **Build a grader image** (update `containers/grader/Dockerfile` first if
-    needed):
-
-    ```bash
-    $ docker build -t my-grader:latest containers/grader
-    ```
-
-    ```
-    [+] Building 2.1s (12/12) FINISHED
-    => => naming to docker.io/library/my-grader:latest
-    ```
-
-    **Configure the course** (replace `cs101` with your course slug):
-
-    ```bash
-    $ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
-
---slug cs101 \
- --token-stdin \
- --course-id 12345 \
- --docker-image my-grader:latest \
- --env PYTHONUNBUFFERED=1 \
- --assets-block local-rustfs \
- --s3-prefix graders/cs101/ ```
-
-    ```
-    Course configuration saved as block: ccc-course-cs101
-    ```
-
-    **Create a Prefect deployment**:
-
-    ```bash
-    $ prefect deployment build \
-      canvas_code_correction.flows.correct_submission:correct_submission_flow \
-      -n cs101-corrections \
-      -q course-work-pool-cs101 \
-      -a
-    ```
-
-    ```
-    Deployment built and applied successfully!
-    View deployment in UI: https://app.prefect.cloud/deployments/...
-    ```
-
-    **Start a worker**:
-
-    ```bash
-    $ prefect worker start --pool course-work-pool-cs101
-    ```
-
-    ```
-    Worker started. Polling for flow runs...
-    Connected to work pool 'course-work-pool-cs101'.
-    ```
-
-    **Trigger a test run**:
-
-    ```bash
-    $ prefect deployment run cs101-corrections
-    ```
-
-    ```
-    Flow run submitted: cs101-corrections/alert-marmot
-    ```
-
-    Watch the worker logs to see your grader execute inside a Docker container. If
-    everything is set up correctly, you will see the flow run complete
-    successfully in the Prefect UI.
-
----
-
-## Prerequisites
-
-Before deploying grader tests, ensure you have:
-
-1. **Prefect access** – either [Prefect Cloud](https://app.prefect.cloud) or a
-   self‑hosted Orion instance. See
-   [Setting up Prefect](02-setting-up-prefect.md) for configuration details.
-2. **Docker** – installed locally for building grader images.
-3. **Grader repository** – the course‑specific grader repository with instructor
-   tests.
-4. **Canvas credentials** – API token and course ID stored in `.env` or Prefect
-   blocks.
-5. **`uv`** – installed and the project dependencies resolved (`uv sync`).
-
-!!! tip
-    Export `PREFECT_API_URL`, `PREFECT_API_KEY`, and Canvas credentials before running CLI commands,
-    or update your Prefect profile to include them.
-
-## 1. Local Development with RustFS
-
-CCC includes a lightweight S3‑compatible server (RustFS) for local development
-and testing. It stores assets in the `./workspace` directory and uses fixed
-credentials (`rustfsadmin`/`rustfsadmin`).
-
-### Start RustFS
+For local development with RustFS:
 
 ```bash
 $ poe s3
-```
-
-```
-Starting RustFS server on http://localhost:9000
-Access key: rustfsadmin
-Secret key: rustfsadmin
-Storage directory: ./workspace
-Server ready.
-```
-
-Keep this terminal running. The server listens on `http://localhost:9000`.
-
-### Configure RustFS for CCC
-
-Run the setup script to create a bucket, upload a test asset, and register a
-Prefect S3 block named `local‑rustfs`:
-
-```bash
 $ poe rustfs-setup
-```
-
-```
-✓ RustFS server reachable at http://localhost:9000
-✓ Bucket 'test-assets' created
-✓ Test asset uploaded to s3://test-assets/dev/test.txt
-✓ Prefect S3 block 'local-rustfs' registered
-Local RustFS is ready for use with CCC.
-```
-
-You can now use `--assets-block local-rustfs` when configuring courses for local
-testing.
-
-### Customize RustFS Settings
-
-The setup can be tailored with environment variables:
-
-| Variable             | Default                 | Purpose                |
-| -------------------- | ----------------------- | ---------------------- |
-| `RUSTFS_ENDPOINT`    | `http://localhost:9000` | S3 endpoint URL        |
-| `RUSTFS_ACCESS_KEY`  | `rustfsadmin`           | Access key             |
-| `RUSTFS_SECRET_KEY`  | `rustfsadmin`           | Secret key             |
-| `RUSTFS_BUCKET_NAME` | `test-assets`           | Bucket name            |
-| `RUSTFS_PREFIX`      | `dev`                   | Path prefix for assets |
-
-Example for a production‑like setup:
-
-```bash
-export RUSTFS_ENDPOINT="https://rustfs.example.com"
-export RUSTFS_ACCESS_KEY="your-access-key"
-export RUSTFS_SECRET_KEY="your-secret-key"
-export RUSTFS_BUCKET_NAME="course-assets"
-export RUSTFS_PREFIX="graders/cs101"
-poe rustfs-setup
-```
-
-For detailed RustFS configuration, see [RustFS Storage](07-rustfs-storage.md).
-
-## 2. Build and Publish the Grader Image
-
-1. Update `containers/grader/Dockerfile` (or your course‑specific Dockerfile)
-   with the required dependencies and entrypoint.
-2. Build the image:
-
-```bash
-$ docker build -t jakob1379/canvas-grader:latest containers/grader
-```
-
-3. If you use a remote registry, push the image:
-
-```bash
-$ docker push jakob1379/canvas-grader:latest
-```
-
-!!! note
-    The image tag must be accessible from wherever the Prefect worker runs.  For private registries,
-    ensure the worker environment has the necessary credentials.
-
-## 3. Configure Prefect Blocks
-
-Use the `ccc course setup` CLI to save course settings and associate an S3
-assets block that points to the bucket/prefix containing immutable grader tests.
-
-```bash
-$ ccc course setup \
-  --slug <course-slug> \
-  --token <canvas-token> \
-  --course-id <canvas-course-id> \
-  --docker-image <image:tag> \
-  --env PYTHONUNBUFFERED=1 \
-  --assets-block <block-name> \
-  --s3-prefix graders/<course-slug>/
-```
-
-**Example with local RustFS** (block created by `rustfs‑setup`):
-
-```bash
-$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
-  --slug cs101 \
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
   --token-stdin \
   --course-id 12345 \
-  --docker-image my-grader:latest \
-  --assets-block local-rustfs
+  --slug cs101 \
+  --assets-block local-rustfs \
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101
 ```
 
-**Example with production S3** (block must already exist):
+Expected result:
+
+```text
+✓ Course configuration saved as block: ccc-course-cs101
+```
+
+## What CCC Expects
+
+CCC downloads grader assets from the configured bucket block and prefix into
+`/workspace/assets`. The default grader command is:
+
+```text
+sh /workspace/assets/main.sh
+```
+
+That means your assets prefix should contain an executable `main.sh` plus any
+supporting files your grader needs.
+
+## Step 1: Build and Publish the Grader Image
+
+Build the grader image from your grader repository:
 
 ```bash
-$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
-  --slug cs101 \
+$ docker build -t ghcr.io/example/cs101-grader:latest .
+```
+
+If workers need to pull the image from a registry, push it:
+
+```bash
+$ docker push ghcr.io/example/cs101-grader:latest
+```
+
+For authoring guidance, see
+[Grader Image Guide](../reference/05-grader-image.md).
+
+## Step 2: Put Assets in S3-Compatible Storage
+
+Choose a bucket block and prefix, for example:
+
+- block: `course-assets-cs101`
+- prefix: `graders/cs101/`
+
+Your uploaded assets should include at least:
+
+```text
+graders/cs101/
+  main.sh
+  tests/
+  fixtures/
+```
+
+For local development, `poe rustfs-setup` creates the `local-rustfs` block and
+verifies the test bucket. You still need to place your real grader assets under
+the prefix you plan to use.
+
+## Step 3: Configure the Course Block
+
+Save the image, assets block, prefix, and work pool into the course block:
+
+```bash
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
   --token-stdin \
+  --api-url https://canvas.example.edu \
   --course-id 12345 \
-  --docker-image jakob1379/canvas-grader:latest \
+  --slug cs101 \
   --assets-block course-assets-cs101 \
-  --s3-prefix graders/cs101/
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101
 ```
 
-The command saves a Prefect block named `ccc-course-<course-slug>`.
+If you are using local RustFS, replace `course-assets-cs101` with
+`local-rustfs`.
 
-For more about course configuration, see
-[Configuring a Course](01-configuring-course.md).
-
-## 4. Register a Prefect Deployment
-
-Create a Prefect deployment so CCC flows can be triggered manually, on a
-schedule, or via webhooks.
+## Step 4: Create the Deployment and Start a Worker
 
 ```bash
-$ prefect deployment build \
-  canvas_code_correction.flows.correct_submission:correct_submission_flow \
-  -n <course-slug>-corrections \
-  -q <course-work-pool> \
-  -a
+$ ccc system deploy create ccc-course-cs101
+$ uv run prefect worker start --pool course-work-pool-cs101
 ```
 
-- `-q` specifies the work pool (course‑specific) that matching workers will
-  poll.
-- `-a` applies the deployment immediately.
+The worker host must be able to:
 
-Example:
+- pull the grader image
+- reach the S3-compatible endpoint
+- talk to the Prefect API
+
+## Step 5: Run a Dry Test
+
+Run one submission without posting results:
 
 ```bash
-$ prefect deployment build \
-  canvas_code_correction.flows.correct_submission:correct_submission_flow \
-  -n cs101-corrections \
-  -q course-work-pool-cs101 \
-  -a
+$ ccc course run 98765 --course ccc-course-cs101 --submission-id 54321 --dry-run
 ```
 
-```
-Deployment built and applied successfully!
-View deployment in UI: https://app.prefect.cloud/deployments/...
-```
-
-Alternatively, create deployments through the Prefect UI. For scheduling
-automated runs, see [Scheduling Corrections](03-scheduling-corrections.md).
-
-## 5. Start a Prefect Worker
-
-Launch a worker connected to the course work pool so queued flow runs can
-execute the grader code inside the Docker container.
-
-```bash
-$ prefect worker start --pool <course-work-pool>
-```
-
-Workers can run locally, on a dedicated VM, or inside container orchestration.
-Ensure Docker access is available wherever the worker runs.
-
-Example:
-
-```bash
-$ prefect worker start --pool course-work-pool-cs101
-```
-
-```
-Worker started. Polling for flow runs...
-Connected to work pool 'course-work-pool-cs101'.
-```
-
-For detailed worker configuration, see
-[Local Prefect Worker Guide](06-prefect-agent.md).
-
-## 6. Trigger Test Runs
-
-With the deployment active and a worker online, you can trigger runs in several
-ways:
-
-### Manual Run via CLI
-
-```bash
-$ prefect deployment run <course-slug>-corrections
-```
-
-### One‑Off Run Targeting a Specific Submission
-
-```bash
-$ ccc course run <assignment-id>
-```
-
-### Automatic Runs via Canvas Webhook
-
-Configure the Canvas webhook to call the Prefect webhook URL. When a submission
-is made, CCC will automatically start a correction flow. See
-[Scheduling Corrections](03-scheduling-corrections.md) for webhook setup.
-
-### Run from the Prefect UI
-
-Navigate to the deployment in the Prefect UI and click **Run**.
-
-## 7. Verify and Iterate
-
-1. **Inspect logs** in Prefect to ensure the grader command runs successfully.
-2. **Review artefacts** in the submission workspace (results, points, comments).
-3. **Adjust grader tests** or container configuration as required.
-4. **Rebuild/push the image** when the runtime environment changes.
-5. **Update grader tests** by uploading new files to the S3 bucket/prefix
-   referenced by the Prefect block; the next flow run will pick up the new
-   assets automatically.
-
-For monitoring flow runs and results, see
-[Monitoring Results](04-monitoring-results.md).
+That confirms the image, assets, and runtime wiring are correct before you post
+grades.
 
 ## Troubleshooting
 
-| Problem                        | Likely Cause                                      | Solution                                                                                                               |
-| ------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Worker cannot pull image**   | Missing Docker credentials or incorrect image tag | Ensure the worker environment has credentials for private registries and that the image tag is correct.                |
-| **Canvas API failures**        | Invalid or missing tokens/course IDs              | Verify tokens and course IDs are present in your settings (`.env` or Prefect block).                                   |
-| **Timeouts / resource issues** | Worker host is undersized                         | Use a stronger worker machine or reduce grader workload complexity.                                                    |
-| **No runs start**              | Work pool mismatch or worker not connected        | Confirm the work pool name in the deployment matches the running worker and that the worker log shows it is connected. |
-| **RustFS server unreachable**  | Server not running or wrong endpoint              | Check that `poe s3` is still running and that `RUSTFS_ENDPOINT` matches the server URL.                                |
+### The grader cannot find `main.sh`
 
-Following these steps keeps grader tests aligned with CCC’s Prefect‑based
-orchestration while allowing instructors to iterate rapidly on course‑specific
-grading logic.
+- Confirm the assets prefix really contains `main.sh`.
+- Confirm the course block uses the same prefix you uploaded to.
+
+### The worker cannot pull the image
+
+- Test `docker pull <image:tag>` on the worker host.
+- Add registry credentials if the image is private.
+
+### Asset downloads fail
+
+- Verify the assets block credentials.
+- For local RustFS, rerun:
+
+  ```bash
+  $ poe rustfs-setup
+  ```
+
+## Related Docs
+
+- [Configuring a Course](01-configuring-course.md)
+- [Setting Up Prefect](02-setting-up-prefect.md)
+- [RustFS Storage](07-rustfs-storage.md)
+- [Grader Image Guide](../reference/05-grader-image.md)

--- a/docs/platform-setup/06-prefect-agent.md
+++ b/docs/platform-setup/06-prefect-agent.md
@@ -1,275 +1,127 @@
 # Running Prefect Locally for Development
 
-!!! note "Audience"
-    CCC developers and testers **Prerequisites**: Python 3.13+,
-    Docker installed and running, CCC installed (`uv install -e .`)
+This page is the **developer-focused** companion to
+[Setting Up Prefect](02-setting-up-prefect.md). Use it when you want a fast
+local loop for CCC changes, not just an operator setup.
 
-**Prefect Orion** is the local server that orchestrates correction workflows
-when you are developing or testing CCC. This guide shows you how to start Orion,
-create a local work pool, and launch a worker that picks up flow runs, **all in
-3 minutes**.
+## Try It Now
 
-!!! note "Try It Now (90 seconds)"
+Start the local stack in two terminals.
 
-    If you have a course configured with slug `cs101`, run these commands to start
-    a local Prefect server and a worker:
-
-    ```bash
-    $ prefect server start
-    ```
-
-    Expected output (server starts on http://127.0.0.1:4200):
-
-    ```
-     ___ ___ ___ ___ ___ ___ _____
-    | _ \ _ \ __| __| __/ __|_   _|
-    |  _/   / _|| _|| _| (__  | |
-    |_| |_|_\___|_| |_| \___| |_|
-
-    Starting Prefect server...
-    Server started on http://127.0.0.1:4200
-    ```
-
-    In a **second terminal**, create a work pool and start a worker for the
-    `canvas-corrections` queue:
-
-    ```bash
-    $ prefect work-pool create --type process canvas-corrections
-    $ prefect worker start --pool canvas-corrections
-    ```
-
-    Expected worker output:
-
-    ```
-    Starting worker for pool 'canvas-corrections'...
-    Worker 'eager-panda' started!
-    Waiting for flow runs...
-    ```
-
-    Your local Prefect environment is now ready. Keep both terminals open.
-
----
-
-## Why Run Prefect Locally?
-
-When you are developing grader images, writing tests, or debugging correction
-logic, you need a **fast feedback loop**. A local Prefect server
-(`prefect server start`) gives you:
-
-- **No network latency** – all communication stays on your machine.
-- **Full control** – you can restart, reset, or inspect the server state.
-- **Isolation** – your experiments do not affect production corrections.
-
-This setup is **not for production**; use Prefect Cloud or a self‑hosted Prefect
-server for real courses. For production deployment, see
-[Setting up Prefect](02-setting-up-prefect.md).
-
-## Prerequisites
-
-Before you start, ensure you have:
-
-1. **Python 3.13+** and `uv` installed (the project uses `uv run`).
-2. **Docker** installed and running (the worker launches grader containers).
-3. **CCC installed** in editable mode:
-   ```bash
-   $ uv install -e .
-   ```
-4. **A configured course** (if you want to run actual corrections). Complete
-   [Configuring a Course](01-configuring-course.md) first.
-
-## Step 1: Start the Prefect Orion Server
-
-Open a terminal in the project root and run:
+Terminal 1:
 
 ```bash
-$ prefect server start
+$ poe prefect
 ```
 
-### What you will see
+Terminal 2:
 
-The command prints the Prefect ASCII logo and starts the server on
-`http://127.0.0.1:4200`. The output looks like this:
-
-```
- ___ ___ ___ ___ ___ ___ _____
-| _ \ _ \ __| __| __/ __|_   _|
-|  _/   / _|| _|| _| (__  | |
-|_| |_|_\___|_| |_| \___| |_|
-
-Starting Prefect server...
-Server started on http://127.0.0.1:4200
+```bash
+$ uv run prefect work-pool create --type process canvas-corrections
+$ uv run prefect worker start --pool canvas-corrections
 ```
 
-!!! note
-    The server runs in the foreground. Keep this terminal open. You can
-    stop it with `Ctrl+C`.
+If you want RustFS too, add:
 
-### Verify the server
+```bash
+$ poe s3
+$ poe rustfs-setup
+```
 
-Open your browser to `http://127.0.0.1:4200`. You should see the Prefect UI with
-an empty dashboard. No login is required for the local server.
+## Why Run Prefect Locally
+
+Use a local Prefect server when you want to:
+
+- iterate on flow code quickly
+- inspect flow runs without a remote dependency
+- reproduce worker and deployment behavior on one machine
+
+## Step 1: Start the Server
+
+```bash
+$ poe prefect
+```
+
+The UI and API are available at `http://localhost:4200`.
 
 ## Step 2: Create a Local Work Pool
 
-A **work pool** is a named queue that workers subscribe to. For local
-development, create a pool of type `process` (the worker will run flows in
-subprocesses).
+```bash
+$ uv run prefect work-pool create --type process canvas-corrections
+```
 
-In a **second terminal** (same project directory), run:
+You can use any pool name, but your worker and deployment must match it.
+
+## Step 3: Start the Worker
 
 ```bash
-$ prefect work-pool create --type process canvas-corrections
+$ uv run prefect worker start --pool canvas-corrections
 ```
 
-**Expected output:**
+Expected output begins with:
 
-```
-Created work pool 'canvas-corrections' (type: process)
-```
-
-The pool is now visible in the Prefect UI under **Work Pools**.
-
-!!! note "Why canvas-corrections?" This is a simple local queue name for
-testing. CCC can use any queue name as long as your deployment and worker use
-the same pool. deployment targets the same pool.
-
-## Step 3: Start a Worker
-
-**Workers** are processes that pick up flow runs from a work pool and execute
-them. Start a worker for the pool you just created:
-
-```bash
-$ prefect worker start --pool canvas-corrections
-```
-
-**Expected output:**
-
-```
+```text
 Starting worker for pool 'canvas-corrections'...
-Worker 'eager-panda' started!
-Waiting for flow runs...
 ```
 
-The worker will stay alive and wait for flow runs. It needs:
+## Step 4: Use a Course Block That Targets the Same Pool
 
-- **Access to Docker** (to launch grader containers).
-- **The same environment variables** (Canvas token, etc.) that you configured in
-  the course block.
-- **Network connectivity** to the local Orion server (already satisfied).
-
-Keep this terminal open as well. You can run multiple workers for the same pool
-to distribute load.
-
-## Step 4: Trigger a Test Correction
-
-With the server running and a worker waiting, trigger a correction flow to
-verify everything works.
-
-### Option A: Use the CCC CLI (recommended)
-
-If you have a course configured, run a one‑off correction for a specific
-assignment:
+For local runs, create or update a course block with:
 
 ```bash
-$ ccc course run <assignment-id>
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
+  --token-stdin \
+  --course-id 12345 \
+  --slug cs101 \
+  --assets-block local-rustfs \
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool canvas-corrections
 ```
 
-Replace `<assignment-id>` with the numeric Canvas assignment ID. The command
-creates a flow run that your local worker will pick up immediately.
-
-### Option B: Use the Prefect CLI
-
-First, create a deployment that targets your local pool (replace `cs101` with
-your course slug):
+Then create the deployment:
 
 ```bash
-$ prefect deployment build \
-  canvas_code_correction.flows.correct_submission:correct_submission_flow \
-  -n cs101-corrections \
-  -q canvas-corrections \
-  -a
+$ ccc system deploy create ccc-course-cs101
 ```
 
-Then run the deployment:
+## Step 5: Trigger Work
+
+For quick validation, prefer the CCC CLI:
 
 ```bash
-$ prefect deployment run cs101-corrections
+$ ccc course run 98765 --course ccc-course-cs101 --submission-id 54321 --dry-run
 ```
 
-### Option C: Use the Prefect UI
+To inspect recent flow activity:
 
-1. Open `http://127.0.0.1:4200`.
-2. Navigate to **Deployments** and find your deployment.
-3. Click the **Run** button.
-
-### Expected outcome
-
-Watch the worker terminal. You should see logs like:
-
+```bash
+$ uv run prefect flow-run ls --limit 5
 ```
-Picked up flow run 'golden-sloth' from pool 'canvas-corrections'
-Executing flow 'correct-submission-flow'...
-Downloading submission from Canvas...
-Pulling grader image 'yourusername/canvas-grader:latest'...
-Running grader container...
-```
-
-If the flow completes successfully, you will see a final log line with the score
-submitted to Canvas.
-
-## Step 5: Configure Prefect Blocks Locally
-
-For local runs, you must ensure the **Prefect blocks** that store Canvas
-credentials, runner configuration, and S3 assets already exist. The
-`ccc course setup` command creates these blocks for you.
-
-If you have not configured a course yet, follow
-[Configuring a Course](01-configuring-course.md). The blocks are stored in the
-local Orion server's SQLite database, so they persist across server restarts.
-
-!!! note "Important" When you run `ccc course run` locally, you do **not** need
-to set `PREFECT_API_KEY` (the local server does not require authentication).
-However, you still need the blocks that hold your Canvas token and S3 bucket
-details.
 
 ## Troubleshooting
 
-### The worker cannot connect to the server
+### The local server is up but CCC cannot reach it
 
-- Ensure the Orion server is still running (first terminal).
-- Check that the worker uses the same API URL (default
-  `http://127.0.0.1:4200/api`). The local worker auto‑discovers it; if you
-  changed the port, set `PREFECT_API_URL`.
+- Confirm `PREFECT_API_URL=http://localhost:4200/api`
+- Re-run `ccc system status`
 
-### The worker fails to pull the Docker image
+### The worker is running but nothing executes
 
-- Verify Docker is running (`docker ps`).
-- Ensure the grader image exists locally or is accessible from Docker Hub.
+- Confirm the course block and worker use the same pool name
+- Inspect the deployment:
 
-### The flow run stays `Scheduled` forever
+  ```bash
+  $ uv run prefect deployment inspect webhook-correction-flow/ccc-cs101-deployment
+  ```
 
-- Confirm the worker is subscribed to the correct pool (`canvas-corrections`).
-- Look for errors in the worker logs (the second terminal).
+### RustFS is not available
 
-### Blocks are missing
-
-- Run `ccc course setup` to create the necessary blocks.
-- List existing blocks with `prefect block list`.
+- Start it with `poe s3`
+- Register the local block with `poe rustfs-setup`
 
 ## Next Steps
 
-Your local Prefect environment is ready for development. Next, you can:
-
-- **Write and test grader images** – see
-  [Creating a Grader Image](../tutorial/03-creating-grader-image.md).
-- **Upload test assets to S3** – see
-  [Deploying Tests to CCC](05-deploying-tests-to-ccc.md).
-- **Schedule corrections** (on a local schedule) – follow
-  [Scheduling Corrections](03-scheduling-corrections.md).
-- **Monitor runs and logs** in the Prefect UI – see
-  [Monitoring Results](04-monitoring-results.md).
-
-!!! tip
-    When you are done testing, stop the Orion server (`Ctrl+C` in the first terminal) and the worker
-    (`Ctrl+C` in the second terminal). The local SQLite database (`~/.prefect/orion.db`) retains
-    blocks and run history for the next session.
+- [Monitoring Results](04-monitoring-results.md)
+- [CLI Reference](../reference/02-cli.md)
+- [Architecture Overview](../reference/01-architecture.md)

--- a/docs/platform-setup/07-rustfs-storage.md
+++ b/docs/platform-setup/07-rustfs-storage.md
@@ -1,152 +1,92 @@
 # RustFS Storage
 
-**Audience**: CCC platform operators **Prerequisites**: Docker installed, Python
-environment with `uv` (see [Project Setup](../../README.md))
+**RustFS** is the repo's local **S3-compatible storage** option for development
+and testing.
 
-**RustFS** is a lightweight S3‑compatible storage server that CCC can use for
-local development and testing. With RustFS you can emulate cloud storage on your
-laptop, upload grader assets, and run the entire correction pipeline without
-connecting to a real S3 service.
+## Try It Now
 
-!!! note "Try It Now (2 minutes)"
-
-    If you have Docker running, execute these three commands to start RustFS,
-    create a test bucket, and register a Prefect block:
-
-    ```bash
-    $ poe s3
-    ```
-
-    Expected output (first line):
-
-    ```
-     INFO  rustfs > Starting server on http://localhost:9000
-    ```
-
-    In a **second terminal**, run:
-
-    ```bash
-    $ poe rustfs-setup
-    ```
-
-    Expected output:
-
-    ```
-    ✅ RustFS is reachable at http://localhost:9000
-    ✅ Created bucket 'test-assets'
-    ✅ Uploaded test asset 'greeting.txt'
-    ✅ Registered Prefect S3 block 'local-rustfs'
-    ```
-
-    Now you can use the block `local-rustfs` when you
-    [configure a course](01-configuring-course.md).
-
----
-
-## What is RustFS?
-
-RustFS is a minimal S3‑compatible object‑storage server written in Rust. It runs
-in a Docker container, stores data in a local directory (`./workspace`), and
-uses the same API as AWS S3. CCC uses RustFS for **local development** and
-**integration testing**: you can upload grader assets, run corrections, and
-verify the whole storage layer without leaving your machine.
-
-## Running RustFS Locally
-
-Start the RustFS server with the project’s Poe task:
+In one terminal:
 
 ```bash
 $ poe s3
 ```
 
-You’ll see output similar to:
-
-```
- INFO  rustfs > Starting server on http://localhost:9000
- INFO  rustfs > Default credentials: rustfsadmin / rustfsadmin
- INFO  rustfs > Data directory: ./workspace
- INFO  rustfs > Press Ctrl+C to stop
-```
-
-The server is now listening at `http://localhost:9000`. Keep this terminal open
-while you work with RustFS.
-
-## Setting Up for Testing
-
-Once RustFS is running, open another terminal and run the setup script:
+In a second terminal:
 
 ```bash
 $ poe rustfs-setup
 ```
 
-This script performs four actions:
+Expected setup output includes:
 
-1. **Verifies** RustFS is reachable.
-2. **Creates** a bucket named `test‑assets`.
-3. **Uploads** a test asset file (`greeting.txt`).
-4. **Registers** a Prefect S3 block named `local‑rustfs`.
-
-You’ll see the success messages shown in the “Try It Now” section. The Prefect
-block is now ready to be used by CCC.
-
-## Configuration
-
-You can customize RustFS behavior with environment variables. The defaults are:
-
-| Variable             | Default                 | Purpose                       |
-| -------------------- | ----------------------- | ----------------------------- |
-| `RUSTFS_ENDPOINT`    | `http://localhost:9000` | S3 endpoint URL               |
-| `RUSTFS_ACCESS_KEY`  | `rustfsadmin`           | Access key                    |
-| `RUSTFS_SECRET_KEY`  | `rustfsadmin`           | Secret key                    |
-| `RUSTFS_BUCKET_NAME` | `test‑assets`           | Bucket for grader assets      |
-| `RUSTFS_PREFIX`      | `dev`                   | Path prefix inside the bucket |
-
-For example, to point the setup script at a production‑like RustFS instance:
-
-```bash
-export RUSTFS_ENDPOINT="https://rustfs.example.com"
-export RUSTFS_ACCESS_KEY="your-access-key"
-export RUSTFS_SECRET_KEY="your-secret-key"
-export RUSTFS_BUCKET_NAME="course-assets"
-export RUSTFS_PREFIX="graders/cs101"
-poe rustfs-setup
+```text
+✓ RustFS is reachable at http://localhost:9000
+✓ Created bucket 'test-assets'
+✓ Uploaded test asset to 'test-assets/dev/test.txt'
 ```
 
-The script will create the bucket `course‑assets` and register a Prefect block
-with the supplied credentials.
+If Prefect is reachable too, the script also registers the `local-rustfs`
+Prefect block.
+
+## What the Setup Script Does
+
+`scripts/setup_rustfs.py` performs these steps:
+
+1. probes the RustFS endpoint
+2. creates the configured bucket if needed
+3. uploads a small test asset
+4. registers the `local-rustfs` block when Prefect is available
+
+## Default Configuration
+
+These environment variables control the setup:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RUSTFS_ENDPOINT` | `http://localhost:9000` | S3-compatible endpoint |
+| `RUSTFS_ACCESS_KEY` | `rustfsadmin` | Access key |
+| `RUSTFS_SECRET_KEY` | `rustfsadmin` | Secret key |
+| `RUSTFS_BUCKET_NAME` | `test-assets` | Bucket name |
+| `RUSTFS_PREFIX` | `dev` | Prefix used for the sample asset |
 
 ## Using RustFS with CCC
 
-When you [configure a course](01-configuring-course.md), pass the block name
-created by the setup script (by default `local‑rustfs`) to the `--assets‑block`
-flag:
+Point a course block at the registered local block and choose the prefix where
+your grader assets live:
 
 ```bash
-$ ccc course setup \
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
+  --token-stdin \
+  --course-id 12345 \
   --slug cs101 \
   --assets-block local-rustfs \
-  --s3-prefix dev/
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101
 ```
 
-CCC will store and retrieve grader assets from your RustFS bucket. If you need
-to change the bucket or prefix later, update the Prefect block with
-`prefect block edit` and reconfigure the course.
+CCC will download grader assets from that block and prefix into
+`/workspace/assets`.
 
-## Production Considerations
+## Example Override
 
-RustFS is designed for **development and testing**. It does not provide
-durability, backups, or fine‑grained access controls. For production workloads,
-use a dedicated S3‑compatible service:
+```bash
+$ export RUSTFS_ENDPOINT="https://rustfs.example.com"
+$ export RUSTFS_ACCESS_KEY="your-access-key"
+$ export RUSTFS_SECRET_KEY="your-secret-key"
+$ export RUSTFS_BUCKET_NAME="course-assets"
+$ export RUSTFS_PREFIX="graders/cs101"
+$ poe rustfs-setup
+```
 
-- **AWS S3** (with appropriate IAM policies)
-- **MinIO** (self‑hosted, production‑ready)
-- **Google Cloud Storage** (S3 interoperability mode)
-- **Azure Blob Storage** (S3 compatibility layer)
+## Production Note
 
-When you switch to a production storage service, update the environment
-variables and re‑run `rustfs‑setup` (or create the Prefect block manually). The
-rest of CCC (course configuration, scheduling, and correction flows) remains
-unchanged.
+RustFS is for **development and testing**. For production use a managed or
+production-ready S3-compatible service and create the corresponding Prefect
+block there.
 
-!!! note "Next Step"
-    After setting up storage, [configure a course](01-configuring-course.md) to start scheduling corrections.
+## Related Docs
+
+- [Configuring a Course](01-configuring-course.md)
+- [Deploying Grader Tests to CCC](05-deploying-tests-to-ccc.md)
+- [Configuration Reference](../reference/03-configuration.md)

--- a/docs/reference/01-architecture.md
+++ b/docs/reference/01-architecture.md
@@ -30,9 +30,9 @@ by default.
 - **GraderExecutor** – Runs the instructor‑provided command inside Docker using
   a dedicated workspace and explicit resource limits.
 - **Grader Configuration Blocks** – Prefect configuration blocks store course‑specific
-  grader images, resource limits, per‑assignment commands, and environment
-  variables. Each course provisions a dedicated Prefect Docker work pool bound
-  to its grader image.
+  grader images, resource limits, commands, and environment variables. Course
+  blocks store the target work pool name; operators create and manage the
+  matching Prefect work pools and workers separately.
 - **ResultCollector** – Extracts `points.txt`, `comments.txt`, artefacts, and
   metadata produced by the grader and prepares zipped feedback for upload.
 - **CanvasUploader** – Posts comments and grades back to Canvas while skipping

--- a/docs/reference/02-cli.md
+++ b/docs/reference/02-cli.md
@@ -1,166 +1,131 @@
 # CLI Reference
 
-Use the `ccc` CLI to configure courses, run corrections, and operate the
-webhook/deployment stack.
+The `ccc` CLI has two top-level command groups:
 
-CCC groups commands by intent:
-
-- `ccc course ...` for **course administration**
-- `ccc system ...` for **platform operations**
+- `ccc course` for **course-specific operations**
+- `ccc system` for **platform operations**
 
 Python requirement: **3.13+**.
 
 ## Try It Now
 
-Run help to confirm the CLI is available:
-
 ```bash
 $ ccc --help
 ```
 
-Expected output (abbreviated):
+Expected output begins with:
 
-```bash
+```text
 Usage: ccc [OPTIONS] COMMAND [ARGS]...
-
-Options:
-  --version  Show version information
-  --help     Show this message and exit
-
-Commands:
-  course  Course administration commands
-  system  Platform administration commands
 ```
 
-If you have not activated the environment created by `uv sync`, run commands
-with `uv run`:
+If you have not activated `.venv`, prefix commands with `uv run`.
 
-```bash
-$ uv run ccc --help
-```
+## Important Note About Help Output
 
-## Command Groups
+`ccc course setup` and `ccc course run` accept additional options that are
+parsed after the Typer entrypoint. That means `--help` only shows the top-level
+subcommand help, not every course-specific flag. The flag list below reflects
+the actual parser in `src/canvas_code_correction/cli_course.py`.
 
-### Course Commands
+## Top-Level Commands
 
-Use course commands when you are configuring or grading a specific Canvas
-course.
-
-```bash
-$ ccc course --help
-```
+### `ccc course`
 
 Available subcommands:
 
-- `setup` – guided setup (interactive by default)
-- `run` – run corrections for an assignment or one submission
-- `list` – list saved course config blocks
+- `setup`
+- `run`
+- `list`
 
-### System Commands
-
-Use system commands when you are managing infrastructure, webhook serving, or
-deployments.
-
-```bash
-$ ccc system --help
-```
+### `ccc system`
 
 Available subcommands:
 
-- `webhook serve` – start webhook API server
-- `deploy create` – create/update a Prefect deployment for a course block
-- `status` – show local platform health checks
+- `webhook serve`
+- `deploy create`
+- `status`
 
-## Course Commands
+## `ccc course setup`
 
-### `ccc course setup`
+Creates or updates a `ccc-course-<slug>` Prefect block.
 
-Use guided setup to collect required values in dependency order (token first,
-then Canvas-derived data).
+### Real flags
 
-Usage:
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--token` | Canvas token | prompt in interactive mode |
+| `--token-stdin` | Read the Canvas token from stdin | disabled |
+| `--api-url`, `-u` | Canvas base URL | `https://canvas.instructure.com` |
+| `--course-id`, `-c` | Canvas course ID | interactive selection |
+| `--docker-image`, `-d` | Grader image | `jakob1379/canvas-grader:latest` |
+| `--map-assignments`, `--test-map` | Assignment-to-test mapping | repeatable |
+| `--env`, `-e` | Extra grader env in `KEY=VALUE` form | repeatable |
+| `--interactive` | Force prompts | enabled |
+| `--no-interactive` | Disable prompts | disabled |
+| `--assets-block` | Assets block name | prompt in interactive mode |
+| `--slug` | Course slug | inferred or prompted |
+| `--assets-prefix` | Assets prefix inside the bucket | `graders/<slug>/` |
+| `--work-pool` | Prefect work pool name | `course-work-pool-<slug>` |
 
-```bash
-$ ccc course setup [OPTIONS]
-```
-
-Key options:
-
-| Option                           | Description                              | Default                          |
-| -------------------------------- | ---------------------------------------- | -------------------------------- |
-| `--token`, `-t`                  | Canvas API token                         | prompted in interactive mode     |
-| `--token-stdin`                  | Read Canvas API token from stdin         | `false`                          |
-| `--api-url`                      | Canvas base URL                          | `https://canvas.instructure.com` |
-| `--course-id`, `-c`              | Skip interactive course selection        | interactive select               |
-| `--assets-block`, `-a`           | Prefect S3 block name                    | prompted in interactive mode     |
-| `--assets-prefix`, `-p`          | Asset path prefix                        | `""`                             |
-| `--slug`, `-s`                   | Course slug used for block name          | inferred or prompted             |
-| `--docker-image`, `-d`           | Grader image                             | optional                         |
-| `--work-pool`, `-w`              | Prefect work pool name                   | optional                         |
-| `--test-map`                     | Mapping `assignment_id:/path/to/test.py` | optional, repeatable             |
-| `--env`, `-e`                    | Extra grader env values `KEY=VALUE`      | optional, repeatable             |
-| `--interactive/--no-interactive` | Prompt for missing values                | interactive                      |
-
-Example (non-interactive with stdin token):
+### Example
 
 ```bash
 $ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
   --token-stdin \
+  --api-url https://canvas.example.edu \
   --course-id 12345 \
-  --assets-block course-assets-cs101 \
   --slug cs101 \
-  --test-map 59160606:/tests/assignment_1.py
+  --assets-block course-assets-cs101 \
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101 \
+  --env PYTHONUNBUFFERED=1
 ```
 
-Expected output (abbreviated):
-
-```bash
-Canvas API token validated successfully
-Course ID 12345 validated
-Course configuration saved as block: ccc-course-cs101
-```
-
-Common error example:
+### Common error
 
 ```bash
 $ ccc course setup --no-interactive --course-id 12345 --assets-block course-assets-cs101
-Error: --token or --token-stdin is required in non-interactive mode
 ```
 
-### `ccc course run`
+Expected output:
 
-Run grading for one assignment (batch) or one submission.
+```text
+--token or --token-stdin is required in non-interactive mode
+```
 
-Usage:
+## `ccc course run`
+
+Runs corrections for one assignment or one submission.
+
+### Real flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `ASSIGNMENT_ID` | Canvas assignment ID | required |
+| `--submission-id` | Limit the run to one submission | batch mode |
+| `--course`, `-c` | Course block name | `default-course` |
+| `--download-dir` | Directory for downloaded files | temporary directory |
+| `--dry-run` | Skip upload side effects | disabled |
+
+### Examples
+
+Batch run:
 
 ```bash
-$ ccc course run <assignment-id> [OPTIONS]
+$ ccc course run 98765 --course ccc-course-cs101
 ```
 
-Options:
-
-| Option            | Description                      | Default          |
-| ----------------- | -------------------------------- | ---------------- |
-| `--submission-id` | Limit to one submission          | batch mode       |
-| `--course`, `-c`  | Course block name                | `default-course` |
-| `--download-dir`  | Directory for downloaded files   | temp directory   |
-| `--dry-run`       | Skip grading upload side effects | `false`          |
-
-Single-submission example:
+Single submission:
 
 ```bash
-$ ccc course run 12345 --submission-id 67890 --course ccc-course-cs101 --dry-run
+$ ccc course run 98765 --course ccc-course-cs101 --submission-id 54321 --dry-run
 ```
 
-Batch example:
+## `ccc course list`
 
-```bash
-$ ccc course run 12345 --course ccc-course-cs101
-```
-
-### `ccc course list`
-
-List all configured course blocks:
+Lists configured course blocks.
 
 ```bash
 $ ccc course list
@@ -169,52 +134,51 @@ $ ccc course list
 Expected output is a table containing block name, Canvas course ID, grader
 image, and assets block.
 
-## System Commands
+## `ccc system webhook serve`
 
-### `ccc system webhook serve`
-
-Start the FastAPI webhook server.
+Starts the FastAPI webhook server.
 
 ```bash
 $ ccc system webhook serve --host 127.0.0.1 --port 8080
 ```
 
-Expected output (abbreviated):
+Expected output:
 
-```bash
+```text
 Starting webhook server on 127.0.0.1:8080
 ```
 
-### `ccc system deploy create`
+## `ccc system deploy create`
 
-Create or update a deployment for a configured course block.
+Creates or updates the built-in webhook deployment for a course block.
 
 ```bash
 $ ccc system deploy create ccc-course-cs101
 ```
 
-Expected output (abbreviated):
+Expected output includes:
 
-```bash
+```text
 Creating deployment for course block: ccc-course-cs101
-Deployment '...' created/updated successfully
+Deployment 'ccc-cs101-deployment' created/updated successfully
 ```
 
-### `ccc system status`
+## `ccc system status`
 
-Check local platform status (Prefect and RustFS probes).
+Checks local Prefect and RustFS connectivity.
 
 ```bash
 $ ccc system status
 ```
 
-Expected output includes `Prefect server` and `RustFS (S3)` health lines.
+Expected output contains health lines for:
 
-## Global Options
+- `Prefect server`
+- `RustFS (S3)`
+
+## Global Option
 
 ### `--version`
-
-Print installed CLI version:
 
 ```bash
 $ ccc --version
@@ -222,13 +186,12 @@ $ ccc --version
 
 Expected output:
 
-```bash
+```text
 Canvas Code Correction 2.0.0a0
 ```
 
 ## Related Docs
 
-- [Architecture Overview](01-architecture.md)
 - [Configuration Reference](03-configuration.md)
 - [Configuring a Course](../platform-setup/01-configuring-course.md)
-- [Setting up Prefect](../platform-setup/02-setting-up-prefect.md)
+- [Setting Up Prefect](../platform-setup/02-setting-up-prefect.md)

--- a/docs/reference/03-configuration.md
+++ b/docs/reference/03-configuration.md
@@ -1,141 +1,178 @@
 # Configuration Reference
 
-CCC configuration is stored in Prefect blocks and read at runtime by CLI
-commands.
+CCC loads runtime configuration from **Prefect course blocks** and a small set
+of environment variables.
 
 ## Try It Now
 
-Create a course block with the minimum required settings:
+Create a course block:
 
 ```bash
-$ ccc course setup \
-  --slug cs101 \
-  --course-id 12345 \
-  --assets-block course-assets-cs101
-```
-
-Secure non-interactive variant:
-
-```bash
-$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
   --token-stdin \
-  --slug cs101 \
+  --api-url https://canvas.example.edu \
   --course-id 12345 \
-  --assets-block course-assets-cs101
+  --slug cs101 \
+  --assets-block course-assets-cs101 \
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101
 ```
 
-Expected output:
-
-```bash
-Course configuration saved as block: ccc-course-cs101
-```
-
-Verify the block exists:
+Verify it:
 
 ```bash
 $ ccc course list
 ```
 
-## Configuration Model
+## Runtime Loading Path
 
-CCC loads settings from `ccc-course-<slug>` blocks using
-`Settings.from_course_block`.
+CCC turns a `ccc-course-<slug>` block into runtime settings with:
 
-The model is defined in `src/canvas_code_correction/config.py` and includes:
+- `canvas_code_correction.bootstrap.load_course_block`
+- `canvas_code_correction.bootstrap.load_settings_from_course_block`
 
-- **Canvas**: `api_url`, `token`, `course_id`
-- **Assets**: `bucket_block`, `path_prefix`
-- **Grader**: `docker_image`, `command`, `timeout_seconds`, `memory_mb`,
-  `upload_check_duplicates`, `upload_comments`, `upload_grades`,
-  `upload_verbose`, `work_pool_name`, `env`
-- **Workspace**: `root`
-- **Webhook**: `secret`, `deployment_name`, `enabled`, `require_jwt`,
-  `rate_limit`
+The runtime model itself lives in `src/canvas_code_correction/config.py`.
 
-## How You Configure It
+## Runtime Settings Model
 
-### Guided setup (recommended first run)
+### Canvas
 
-```bash
-$ ccc course setup
-```
+- `api_url`
+- `token`
+- `course_id`
 
-Use this when you want token validation, course discovery, and optional
-assignment-to-test mapping.
+### Assets
 
-### Direct setup (automation-friendly)
+- `bucket_block`
+- `path_prefix`
 
-```bash
-$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
-  --token-stdin \
-  --slug cs101 \
-  --course-id 12345 \
-  --assets-block course-assets-cs101 \
-  --s3-prefix graders/cs101/ \
-  --docker-image yourusername/canvas-grader:latest \
-  --work-pool course-work-pool-cs101 \
-  --env DEBUG=true
-```
+### Grader
+
+- `docker_image`
+- `work_pool_name`
+- `env`
+- `command`
+- `timeout_seconds`
+- `memory_mb`
+- `upload_check_duplicates`
+- `upload_comments`
+- `upload_grades`
+- `upload_verbose`
+
+### Workspace
+
+- `root`
+
+### Webhook
+
+- `secret`
+- `deployment_name`
+- `enabled`
+- `require_jwt`
+- `rate_limit`
+- `allow_canvas_api_fallback`
+
+## Persisted Course Block Fields
+
+The `CourseConfigBlock` in
+`src/canvas_code_correction/prefect_blocks/canvas.py` persists these important
+fields:
+
+- `canvas_api_url`
+- `canvas_token`
+- `canvas_course_id`
+- `asset_bucket_block`
+- `asset_path_prefix`
+- `grader_image`
+- `work_pool_name`
+- `grader_env`
+- webhook fields such as `deployment_name`, `webhook_enabled`, and
+  `webhook_rate_limit`
+
+## CLI-to-Block Mapping
+
+`ccc course setup` populates these key fields:
+
+| CLI flag | Stored field |
+| --- | --- |
+| `--api-url` | `canvas_api_url` |
+| `--course-id` | `canvas_course_id` |
+| `--assets-block` | `asset_bucket_block` |
+| `--assets-prefix` | `asset_path_prefix` |
+| `--docker-image` | `grader_image` |
+| `--work-pool` | `work_pool_name` |
+| `--env` | `grader_env` |
 
 ## Environment Variables
 
-CCC supports infrastructure and test environment variables.
+### Prefect
 
-### Core runtime
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `PREFECT_API_URL` | Prefect API endpoint | `http://localhost:4200/api` |
+| `PREFECT_API_KEY` | Prefect API key when required | `pnu_...` |
 
-| Variable             | Purpose                       | Example                     |
-| -------------------- | ----------------------------- | --------------------------- |
-| `PREFECT_API_URL`    | Prefect API endpoint          | `http://localhost:4200/api` |
-| `PREFECT_API_KEY`    | Prefect API key (if required) | `pnu_...`                   |
-| `CCC_WORKSPACE_ROOT` | Workspace root directory      | `/tmp/ccc/workspaces`       |
+### Canvas and tests
 
-### Canvas (mainly for tests/scripts)
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `CANVAS_API_URL` | Canvas base URL | `https://canvas.instructure.com` |
+| `CANVAS_API_TOKEN` | Canvas API token | `7~...` |
+| `CANVAS_COURSE_ID` | Test or local course ID | `12345` |
+| `CANVAS_TEST_ASSIGNMENT_ID` | Integration-test assignment ID | `59160606` |
 
-| Variable                    | Purpose                             | Example                          |
-| --------------------------- | ----------------------------------- | -------------------------------- |
-| `CANVAS_API_URL`            | Canvas API URL                      | `https://canvas.instructure.com` |
-| `CANVAS_API_TOKEN`          | Canvas API token                    | `7~...`                          |
-| `CANVAS_COURSE_ID`          | Course ID used in test commands     | `13122436`                       |
-| `CANVAS_TEST_ASSIGNMENT_ID` | Assignment ID for integration tests | `59160606`                       |
+### Workspace
 
-### RustFS / local S3-compatible storage
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `CCC_WORKSPACE_ROOT` | Override workspace root | `/tmp/ccc/workspaces` |
 
-| Variable             | Default                 | Purpose         |
-| -------------------- | ----------------------- | --------------- |
-| `RUSTFS_ENDPOINT`    | `http://localhost:9000` | RustFS endpoint |
-| `RUSTFS_ACCESS_KEY`  | `rustfsadmin`           | Access key      |
-| `RUSTFS_SECRET_KEY`  | `rustfsadmin`           | Secret key      |
-| `RUSTFS_BUCKET_NAME` | `test-assets`           | Bucket name     |
-| `RUSTFS_PREFIX`      | `dev`                   | Asset prefix    |
+### RustFS / S3-compatible storage
 
-Example shell setup:
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RUSTFS_ENDPOINT` | `http://localhost:9000` | S3 endpoint |
+| `RUSTFS_ACCESS_KEY` | `rustfsadmin` | Access key |
+| `RUSTFS_SECRET_KEY` | `rustfsadmin` | Secret key |
+| `RUSTFS_BUCKET_NAME` | `test-assets` | Bucket name |
+| `RUSTFS_PREFIX` | `dev` | Prefix used by `poe rustfs-setup` |
 
-```bash
-$ export PREFECT_API_URL="http://localhost:4200/api"
-$ export CANVAS_API_URL="https://canvas.instructure.com"
-$ export CANVAS_API_TOKEN="your_token"
-$ export CANVAS_COURSE_ID="12345"
-```
+## Known Gap
+
+`allow_canvas_api_fallback` exists in the runtime `WebhookSettings` model, but
+it is **not** currently exposed by `ccc course setup` or persisted on the
+course block. Treat it as an internal runtime field unless that persistence path
+is added.
 
 ## Common Errors
 
-Missing required options during direct configuration:
+Missing token:
 
 ```bash
 $ ccc course setup --no-interactive --slug cs101 --assets-block course-assets-cs101
-Error: --token or --token-stdin is required in non-interactive mode
 ```
 
-Invalid Canvas token during setup:
+Expected output:
+
+```text
+--token or --token-stdin is required in non-interactive mode
+```
+
+Invalid Canvas credentials:
 
 ```bash
 $ ccc course setup --no-interactive --token invalid --course-id 12345 --assets-block course-assets-cs101
-Error: Failed to validate Canvas API token
+```
+
+Expected output begins with:
+
+```text
+Error: Failed to validate Canvas credentials
 ```
 
 ## Related Docs
 
 - [CLI Reference](02-cli.md)
 - [Configuring a Course](../platform-setup/01-configuring-course.md)
-- [Setting up Prefect](../platform-setup/02-setting-up-prefect.md)
 - [RustFS Storage](../platform-setup/07-rustfs-storage.md)

--- a/docs/reference/05-grader-image.md
+++ b/docs/reference/05-grader-image.md
@@ -1,318 +1,126 @@
 # Grader Image Guide
 
-Create a **grader Docker image** for Canvas Code Correction (CCC) to execute
-student submissions in an isolated environment. This guide walks you through
-building, hardening, packaging, and configuring a grader image, from a minimal
-example to production-ready deployment.
+This guide describes the **current grader contract** for CCC:
 
-## Quick Start: Create and Test a Minimal Grader Image
+- CCC pulls a **Docker image** from `grader_image`
+- CCC downloads grader assets into **`/workspace/assets`**
+- the default grader command is **`sh /workspace/assets/main.sh`**
 
-Start with the CCC base image `jakob1379/canvas-grader:latest` (Ubuntu with
-Python 3.13 pre‑installed). Create a **Dockerfile** in your grader repository:
+## Try It Now
+
+Build a minimal grader image:
 
 ```dockerfile
 FROM jakob1379/canvas-grader:latest
 
-# Install any extra system packages your grader needs
-RUN apt-get update && apt-get install -y graphviz && rm -rf /var/lib/apt/lists/*
-```
-
-Build the image:
-
-```bash
-$ docker build -t my-course/grader:latest .
-```
-
-```output
-Sending build context to Docker daemon  4.096kB
-Step 1/2 : FROM jakob1379/canvas-grader:latest
-latest: Pulling from jakob1379/canvas-grader
-Digest: sha256:...
-Status: Downloaded newer image for jakob1379/canvas-grader:latest
- ---> a1b2c3d4e5f6
-Step 2/2 : RUN apt-get update && apt-get install -y graphviz && rm -rf /var/lib/apt/lists/*
- ---> Running in 1234567890ab
-Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
-...
-Setting up graphviz (2.42.2-6) ...
- ---> 7890abcdef12
-Successfully built 7890abcdef12
-Successfully tagged my-course/grader:latest
-```
-
-Test that the image works and includes the added dependency:
-
-```bash
-$ docker run --rm my-course/grader:latest dot -V
-```
-
-```output
-dot - graphviz version 2.42.2 (20200629.0806)
-```
-
-Your minimal grader image is ready. Now add hardening, package your grader code,
-and configure CCC to use it.
-
-## 1. Hardening Steps
-
-The CCC base image already follows security best practices. When you extend it,
-keep these hardening principles in mind.
-
-### Run as a Non‑Root User
-
-The base image creates a non‑root user `app` (UID/GID configurable via build
-arguments). Your container will automatically run as this user, reducing the
-impact of potential container escapes.
-
-Verify the user inside the container:
-
-```bash
-$ docker run --rm my-course/grader:latest whoami
-app
-```
-
-### Dependency Management
-
-Install system dependencies with `apt-get` in a single `RUN` layer and clean up
-afterward to keep the image small:
-
-```dockerfile
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        graphviz \
-        clang \
+    && apt-get install -y --no-install-recommends graphviz \
     && rm -rf /var/lib/apt/lists/*
 ```
 
-For Python dependencies, use `pip` inside your grader test scripts. No need to
-bake them into the image unless they are large or rarely change.
+Then build it:
 
-### Frozen Dependencies
-
-If your grader uses `uv` or `pip-tools`, you can mirror the project’s tooling
-inside the image. Add a `requirements.txt` or `pyproject.toml` and install with
-`--frozen`:
-
-```dockerfile
-COPY requirements.txt .
-RUN uv pip install --frozen -r requirements.txt
+```bash
+$ docker build -t ghcr.io/example/cs101-grader:latest .
 ```
 
-This ensures the same versions are used in the container as in your development
-environment.
+## What the Image Must Provide
 
-## 2. Packaging Course‑Specific Graders
+Your image should provide the runtime required by your grader assets. CCC does
+not expect the assets to be baked into the repo itself; it expects:
 
-Course configuration should **not** require modifying the CCC source tree.
-Instead, ship grader code and test assets with your Docker image (or mount them
-read‑only at runtime) while keeping CCC itself immutable.
+1. a pullable image
+2. a reachable assets block and prefix
+3. a runnable command inside `/workspace/assets`
 
-Two common approaches:
+By default, that command is:
 
-### Approach 1: General‑Purpose Base Image
-
-Start from a lightweight Ubuntu image, install the language runtimes and
-dependencies required by your grader, and copy your test harness into the image
-under `/opt/grader`.
-
-Example Dockerfile:
-
-```dockerfile
-FROM ubuntu:22.04
-
-# Install Python and system dependencies
-RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create non‑root user
-RUN useradd -m -u 1000 app
-USER app
-
-# Copy grader scripts
-COPY --chown=app:app grader /opt/grader
-WORKDIR /opt/grader
-
-# Set entrypoint to the grader harness
-ENTRYPOINT ["python3", "/opt/grader/run.py"]
+```text
+sh /workspace/assets/main.sh
 ```
 
-### Approach 2: Course‑Specialized Image
+If you change the command in the block, keep it compatible with the workspace
+layout described in
+[Authoring Grader Tests](06-authoring-grader-tests.md).
 
-Fork the CCC base image and bake in course‑specific tooling or third‑party
-binaries. When sensitive test assets should **not** be bundled into the image,
-mount them read/executable‑only via Prefect worker volume configuration.
+## Recommended Base Image
 
-Example Dockerfile:
+Start from the project base image unless you have a strong reason not to:
 
 ```dockerfile
 FROM jakob1379/canvas-grader:latest
-
-# Add course‑specific binaries
-COPY --chown=app:app binaries/ /usr/local/bin/
-
-# Install extra system packages
-RUN apt-get update && apt-get install -y \
-    java-17-openjdk \
-    && rm -rf /var/lib/apt/lists/*
-
-# Grader entrypoint is already set by the base image
 ```
 
-In both cases the container should expose the grader entry script via
-`ENTRYPOINT` (or `CMD`) so Prefect can invoke it directly. The script is
-responsible for reading submission files from `/workspace/submission` and
-writing results (`results.json`, `points.txt`, `comments.txt`) back to the
-workspace.
+It already aligns with the repo's Python 3.13 runtime expectations.
 
-## 3. Building and Publishing
+## Build and Publish
 
-Once your Dockerfile packages the grader harness and any required test assets,
-build and optionally push the image to a container registry.
-
-### Build the Image
+Build:
 
 ```bash
-$ docker build -t <registry>/grader:latest .
+$ docker build -t ghcr.io/example/cs101-grader:latest .
 ```
 
-Replace `<registry>` with your Docker Hub username, GitHub Container Registry
-address, or private registry URL.
-
-### Push to a Registry (Recommended)
-
-Tag the image with the full registry path, then push:
+Push when workers need remote access:
 
 ```bash
-$ docker tag <registry>/grader:latest ghcr.io/your‑org/your‑course‑grader:latest
-$ docker push ghcr.io/your‑org/your‑course‑grader:latest
+$ docker push ghcr.io/example/cs101-grader:latest
 ```
 
-```output
-The push refers to repository [ghcr.io/your‑org/your‑course‑grader]
-latest: digest: sha256:... size: 1234
-```
+## Local Validation
 
-Publishing the image allows CCC workers to pull it from a central location.
-
-## 4. Configuring CCC to Use the Image
-
-Provision the course through the Prefect flow/deployment instead of the former
-CLI. The provisioning flow will:
-
-1. Create (or overwrite) the course work pool.
-2. Upload the grader asset folder to S3 via the configured Prefect S3 block.
-3. Persist a `ccc-course-<course_slug>` block referencing the Docker image and
-   latest asset materialization.
-
-### Using the Provisioning Flow Directly
-
-Example Python snippet:
-
-```python
-from pathlib import Path
-from canvas_code_correction.flows.provision import provision_course_flow
-
-provision_course_flow(
-    course_name="my-course",
-    course_id=42,
-    docker_image="ghcr.io/your‑org/your‑course‑grader:latest",
-    assets_path=str(Path("grader-assets")),
-    bucket_block="course-assets-my-course",
-)
-```
-
-Alternatively, build and apply the provided deployment script under
-`canvas_code_correction/deployments/provision.py` so operators can trigger
-provisioning from Prefect Cloud/UI.
-
-### Local Testing with RustFS
-
-For local development and testing, use the RustFS S3‑compatible server:
+Basic smoke test:
 
 ```bash
-# Start RustFS server
-$ poe s3
+$ docker run --rm ghcr.io/example/cs101-grader:latest python3 --version
 ```
 
-```output
-Starting RustFS S3 server on http://localhost:9000
-Credentials: rustfsadmin / rustfsadmin
-```
-
-Set up RustFS for testing:
+If your grader depends on shell tooling, validate that too:
 
 ```bash
-$ poe rustfs-setup
+$ docker run --rm ghcr.io/example/cs101-grader:latest sh -lc 'command -v bash'
 ```
 
-```output
-Verifying RustFS is running...
-Creating bucket 'test-assets'...
-Uploading test asset...
-Registered Prefect S3 block 'local-rustfs'.
-```
+## Wiring the Image into CCC
 
-Configure the course to use the local RustFS block:
+Store the image in the course block:
 
 ```bash
-$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup \
-  --slug my-course \
+$ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
   --token-stdin \
-  --course-id 42 \
-  --docker-image my-course/grader:latest \
-  --assets-block local-rustfs \
-  --s3-prefix dev
+  --course-id 12345 \
+  --slug cs101 \
+  --assets-block course-assets-cs101 \
+  --assets-prefix graders/cs101/ \
+  --docker-image ghcr.io/example/cs101-grader:latest \
+  --work-pool course-work-pool-cs101
 ```
 
-```output
-Course configuration saved as block: ccc-course-my-course
+## Assets Layout
+
+Your chosen assets prefix should contain the files the command needs. With the
+default command, that normally means:
+
+```text
+graders/cs101/
+  main.sh
+  tests/
+  fixtures/
 ```
 
-See the [Deploying Tests to CCC](../platform-setup/05-deploying-tests-to-ccc.md)
-guide for details.
+CCC downloads those files into `/workspace/assets`.
 
-## 5. Validating the Setup
+## Operational Checks
 
-Once provisioning completes and the correction deployment is active, trigger a
-test run via Prefect (UI, CLI, or API).
+Before a real run, confirm:
 
-### Trigger a Test Run Manually
+- the worker host can `docker pull` the image
+- the assets block resolves to the correct bucket
+- the assets prefix contains `main.sh`
+- the worker has enough CPU and memory for the grader workload
 
-```bash
-$ prefect deployment run my-course-corrections
-```
+## Related Docs
 
-### Verify Execution
-
-Inspect the Prefect flow run logs to confirm:
-
-1. The correct Docker image was pulled.
-2. Grader assets were downloaded into the container.
-3. The grader command executed successfully.
-4. Results (`results.json`, `points.txt`, `comments.txt`) were written back to
-   the workspace.
-
-### Common Validation Steps
-
-- **Image accessibility**: Ensure the worker environment has credentials for
-  private registries (if used).
-- **Worker sizing**: Ensure the worker host has enough CPU and memory for your
-  grader workload.
-- **Asset synchronization**: Verify the S3 bucket/prefix contains the latest
-  grader test files.
-
-## Next Steps
-
-Your grader image is now ready for production. Continue with:
-
-- [Writing Grader Tests](../tutorial/04-writing-grader-tests.md) – develop the
-  actual test logic.
-- [Deploying Tests to CCC](../platform-setup/05-deploying-tests-to-ccc.md) –
-  publish tests and configure the CCC platform.
-- [CLI Reference](02-cli.md) – trigger grading flows and monitor results.
-
-**Remember:** Keep your Dockerfile simple. Only add dependencies that are truly
-required for grading. The smaller the image, the faster it starts and the less
-storage it consumes.
+- [Deploying Grader Tests to CCC](../platform-setup/05-deploying-tests-to-ccc.md)
+- [Configuring a Course](../platform-setup/01-configuring-course.md)
+- [Authoring Grader Tests](06-authoring-grader-tests.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ fmt = {cmd = "ruff format", help = "Formats Python code using Ruff."}
 lint = {cmd = "ruff check --fix", help = "Lints and fixes Python code using Ruff."}
 check = {cmd = "pyrefly check", help = "Performs static type checking with Pyrefly."}
 test = {cmd = "pytest", help = "Runs project tests using pytest."}
+test-e2e = {sequence = ["_e2e_stack_up", "_test_e2e"], help = "Starts the local e2e services and runs the e2e pytest suite."}
 all = {sequence = ["fmt", "lint", "check", "test"], help = "Runs all development checks: format, lint, type check, and tests."}
 clean = {cmd = "uvx pyclean . --debris", help = "Clean up Python cache files and test artifacts using pyclean."}
 "ci:lint" = {cmd = "ruff check", help = "Lints code without applying fixes (for CI)."}
@@ -90,6 +91,8 @@ docker-publish = {sequence = ["_docker_build", "_docker_push"], help = "Build an
 serve-docs = {cmd = "zensical serve", help = "Serve documentation locally."}
 _docker_build.cmd = "docker build -t jakob1379/canvas-grader:latest . -f containers/grader/Dockerfile"
 _docker_push.cmd = "docker push jakob1379/canvas-grader:latest"
+_e2e_stack_up.cmd = "docker compose up -d rustfs postgres redis prefect-server prefect-services"
+_test_e2e.cmd = "pytest -m e2e"
 generate-cli-docs.shell = "uv run typer src/canvas_code_correction/cli.py utils docs --title \"CLI Reference\" --name ccc --output 'docs/reference/02-cli.md'"
 prefect.shell = 'prefect server start'
 rustfs-setup.shell = "uv run python scripts/setup_rustfs.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,14 +84,14 @@ test = {cmd = "pytest", help = "Runs project tests using pytest."}
 test-e2e = {sequence = ["_e2e_stack_up", "_test_e2e"], help = "Starts the local e2e services and runs the e2e pytest suite."}
 all = {sequence = ["fmt", "lint", "check", "test"], help = "Runs all development checks: format, lint, type check, and tests."}
 clean = {cmd = "uvx pyclean . --debris", help = "Clean up Python cache files and test artifacts using pyclean."}
-"ci:lint" = {cmd = "ruff check", help = "Lints code without applying fixes (for CI)."}
+"ci:lint" = {cmd = "ruff check", help = "Lints code without applying fixes (for1 CI)."}
 "ci:audit" = {cmd = "uv audit --locked --no-dev --no-extra docs --no-extra test --no-extra ci --preview-features audit", help = "Audits locked runtime dependencies with uv for CI."}
 # Project-specific tasks
 docker-publish = {sequence = ["_docker_build", "_docker_push"], help = "Build and push docker image for base runner"}
 serve-docs = {cmd = "zensical serve", help = "Serve documentation locally."}
 _docker_build.cmd = "docker build -t jakob1379/canvas-grader:latest . -f containers/grader/Dockerfile"
 _docker_push.cmd = "docker push jakob1379/canvas-grader:latest"
-_e2e_stack_up.cmd = "docker compose up -d rustfs postgres redis prefect-server prefect-services"
+_e2e_stack_up.cmd = "docker compose up --wait -d rustfs postgres redis prefect-server prefect-services"
 _test_e2e.cmd = "pytest -m e2e"
 generate-cli-docs.shell = "uv run typer src/canvas_code_correction/cli.py utils docs --title \"CLI Reference\" --name ccc --output 'docs/reference/02-cli.md'"
 prefect.shell = 'prefect server start'


### PR DESCRIPTION
## What changed

This PR rewrites the repo's operator and contributor documentation so it matches the code and CLI that exist today.

Key updates:
- aligned `README.md`, `CONTRIBUTING.md`, and `docs/index.md` with the current repo workflow
- corrected CLI flags and examples, especially `--assets-prefix` vs the old `--s3-prefix`
- replaced outdated Prefect guidance based on manual `prefect deployment build` commands with the current `ccc system deploy create` workflow
- clarified that the built-in CCC deployment is webhook-oriented, and removed misleading cron/batch scheduling guidance
- updated monitoring docs to use actual available Prefect CLI commands
- removed references to nonexistent repo paths such as `containers/grader` from user-facing docs
- refreshed the migration note and architecture wording to match the current module layout and runtime model
- cleaned up `AGENTS.md` drift, including stale task and repo metadata notes

## Why it changed

The documentation had drifted away from the implementation in a few important areas:
- some pages still used obsolete CLI flags and aliases
- several platform guides described an older manual Prefect deployment model
- contributor docs referenced tools and file paths that are no longer used in this repo
- a few operational examples pointed at commands that do not exist in the current installed tooling

That made the docs internally inconsistent and, in places, misleading for both operators and contributors.

## Impact

- operators now get a coherent path for course setup, deployment creation, workers, RustFS, and monitoring
- contributors now get the real repo commands (`poe fmt`, `poe lint`, `poe check`, `poe test`, `poe all`) instead of stale guidance
- the reference docs now match the actual parser behavior and current Prefect integration surface

## Validation

Ran:
- `uv run zensical build --strict --clean`
- repository pre-commit hooks during `git commit`
- repository push hooks during `git push`

Note:
- `zensical` reported `Warning: Strict mode is currently unsupported.` but the docs build completed successfully.
