### PR TITLE
[codex] Fix Prefect deprecation warning in e2e fixture

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 from botocore.client import Config
 from botocore.exceptions import ClientError, EndpointConnectionError
-from prefect.client import get_client
+from prefect.client.orchestration import get_client
 from requests.exceptions import RequestException
 
 


### PR DESCRIPTION
## Summary
- update the e2e fixture to import `get_client` from `prefect.client.orchestration`
- remove the deprecated Prefect import path that emits warnings during e2e test startup
- keep behavior unchanged and avoid adding any warning suppression

## Root cause
`tests/e2e/conftest.py` imported `get_client` from `prefect.client`, which now forwards to the orchestration module with a deprecation warning. That warning will become an error in a future Prefect release.

## Impact
- `pytest -m e2e` no longer picks up this Prefect deprecation warning from the fixture import path
- the runtime path remains aligned with the non-deprecated import already used in application code

## Validation
- pre-commit hooks passed during `git commit`
- push hooks passed during `git push`
- `uv run python -W error::DeprecationWarning -c 'import pathlib, runpy; runpy.run_path(str(pathlib.Path("tests/e2e/conftest.py")))'`
- `uv run pytest tests/e2e --collect-only -q -W error::DeprecationWarning`

Closes #95