### PR TITLE
[codex] Fix local Prefect compose startup ordering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,21 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-  prefect-server:
+  prefect-db-init:
     image: prefecthq/prefect:3-latest
     depends_on:
       postgres:
         condition: service_healthy
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD?You need to set a `POSTGRES_PASSWORD`
+        in the env}
+      PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:${POSTGRES_PASSWORD}@postgres:5432/prefect
+    command: prefect server database upgrade --yes
+  prefect-server:
+    image: prefecthq/prefect:3-latest
+    depends_on:
+      prefect-db-init:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
     environment:
@@ -39,12 +49,21 @@ services:
       PREFECT_REDIS_MESSAGING_DB: 0
     command: prefect server start --no-services
     ports: [4200:4200]
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://127.0.0.1:4200/api/health',
+          timeout=5)
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
   prefect-services:
     image: prefecthq/prefect:3-latest
     depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
+      prefect-server:
         condition: service_healthy
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -59,7 +78,7 @@ services:
     image: prefecthq/prefect:3-latest
     depends_on:
       prefect-server:
-        condition: service_started
+        condition: service_healthy
     environment:
       PREFECT_API_URL: http://prefect-server:4200/api
     command: prefect worker start --pool local-pool
@@ -67,7 +86,7 @@ services:
     image: prefecthq/prefect:3-latest
     depends_on:
       prefect-server:
-        condition: service_started
+        condition: service_healthy
     environment:
       PREFECT_API_URL: http://prefect-server:4200/api
     volumes: [.:/opt/canvas-code-correction]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,8 @@ services:
       prefect-server:
         condition: service_healthy
     environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD?You need to set a `POSTGRES_PASSWORD`
+        in the env}
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:${POSTGRES_PASSWORD}@postgres:5432/prefect
       PREFECT_MESSAGING_BROKER: prefect_redis.messaging
       PREFECT_MESSAGING_CACHE: prefect_redis.messaging


### PR DESCRIPTION
## Summary
This fixes the local Prefect Docker Compose startup ordering so background services do not hit Postgres before the Prefect schema exists.

## Root Cause
`prefect-services` only waited for Postgres and Redis to be healthy. That allowed Prefect background services to start before the API process had applied database migrations, which caused runtime failures like `UndefinedTableError` for `deployment`, `configuration`, and `event_resources`.

## Changes
- add a one-shot `prefect-db-init` service that runs `prefect server database upgrade --yes`
- make `prefect-server` wait for the migration step to complete successfully
- add a healthcheck for `prefect-server` on `/api/health`
- make `prefect-services`, `prefect-worker`, and `webhook-listener` wait for the API to be healthy instead of merely started

## Validation
- `POSTGRES_PASSWORD=testpass docker compose config`
- `POSTGRES_PASSWORD=testpass docker compose up --wait -d postgres redis prefect-server prefect-services`
- verified `prefect-db-init` completed with `Migrations succeeded!`
- local verification then stopped on a separate machine-specific issue: port `4200` was already allocated by another process


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated database-init step to the Docker deployment to ensure database migrations run before the server starts.
  * Strengthened health checks and tightened service startup dependencies so downstream services wait for the server to be fully healthy before launching; environment variable handling for deployment is now stricter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->