### PR TITLE
[codex] Add checked-in count-submitted-files example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Use `ccc course setup` to create a `ccc-course-<slug>` Prefect block that
 stores the Canvas connection, grader image, asset block, asset prefix, and work
 pool name.
 
+For a ready-to-run local grader example, see
+`examples/count-submitted-files/` in the repo root.
+
 ```bash
 $ printf "%s" "$CANVAS_API_TOKEN" | ccc course setup --no-interactive \
   --token-stdin \

--- a/docs/reference/02-cli.md
+++ b/docs/reference/02-cli.md
@@ -50,6 +50,9 @@ Available subcommands:
 
 Creates or updates a `ccc-course-<slug>` Prefect block.
 
+The repo also includes a ready-made local example grader at
+`examples/count-submitted-files/`.
+
 ### Real flags
 
 | Flag | Description | Default |

--- a/docs/reference/06-authoring-grader-tests.md
+++ b/docs/reference/06-authoring-grader-tests.md
@@ -6,6 +6,9 @@ Correction.
 
 ## Quick Start: A Minimal Grader That Works Immediately
 
+The same example is checked into the repo at
+`examples/count-submitted-files/` so you can run it directly.
+
 Copy the following Python script to a file named `grader.py`. This grader lists
 the submission files, awards one point, and writes feedback.
 

--- a/examples/count-submitted-files/README.md
+++ b/examples/count-submitted-files/README.md
@@ -1,0 +1,36 @@
+# Count Submitted Files Example
+
+This is the docs example checked into the repo so it is available immediately
+for local testing.
+
+## Contents
+
+- `assets/grader.py` counts submitted files and writes CCC output files.
+- `assets/main.sh` runs the example with the default CCC container contract.
+- `local-workspace/submission/` is a sample student submission.
+
+## Run It Locally
+
+From the repository root:
+
+```bash
+cd examples/count-submitted-files
+export CCC_WORKSPACE_DIR="$(pwd)/local-workspace"
+export CCC_RESULTS_FILE="$CCC_WORKSPACE_DIR/results.json"
+export CCC_POINTS_FILE="$CCC_WORKSPACE_DIR/points.txt"
+export CCC_COMMENTS_FILE="$CCC_WORKSPACE_DIR/comments.txt"
+python3 assets/grader.py
+cat local-workspace/results.json
+cat local-workspace/comments.txt
+```
+
+## Run It In Docker
+
+```bash
+cd examples/count-submitted-files
+docker run --rm \
+  -v "$(pwd)/assets:/workspace/assets:ro" \
+  -v "$(pwd)/local-workspace:/workspace" \
+  jakob1379/canvas-grader:latest \
+  sh /workspace/assets/main.sh
+```

--- a/examples/count-submitted-files/assets/__init__.py
+++ b/examples/count-submitted-files/assets/__init__.py
@@ -1,0 +1,1 @@
+"""Example grader assets package."""

--- a/examples/count-submitted-files/assets/grader.py
+++ b/examples/count-submitted-files/assets/grader.py
@@ -18,8 +18,8 @@ def submission_files(root: Path) -> list[str]:
 def main() -> None:
     """Count submitted files and write the standard CCC outputs."""
     submission_root = WORKSPACE_ROOT / "submission"
-    if not submission_root.exists():
-        msg = "submission directory missing"
+    if not submission_root.is_dir():
+        msg = "submission directory missing or not a directory"
         raise SystemExit(msg)
 
     files = submission_files(submission_root)

--- a/examples/count-submitted-files/assets/grader.py
+++ b/examples/count-submitted-files/assets/grader.py
@@ -1,0 +1,39 @@
+"""Example grader that counts submitted files."""
+
+import json
+import os
+from pathlib import Path
+
+WORKSPACE_ROOT = Path(os.getenv("CCC_WORKSPACE_DIR", Path.cwd()))
+RESULTS_PATH = Path(os.getenv("CCC_RESULTS_FILE", WORKSPACE_ROOT / "results.json"))
+POINTS_PATH = Path(os.getenv("CCC_POINTS_FILE", WORKSPACE_ROOT / "points.txt"))
+COMMENTS_PATH = Path(os.getenv("CCC_COMMENTS_FILE", WORKSPACE_ROOT / "comments.txt"))
+
+
+def submission_files(root: Path) -> list[str]:
+    """Return sorted relative paths for every submitted file."""
+    return sorted(path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file())
+
+
+def main() -> None:
+    """Count submitted files and write the standard CCC outputs."""
+    submission_root = WORKSPACE_ROOT / "submission"
+    if not submission_root.exists():
+        msg = "submission directory missing"
+        raise SystemExit(msg)
+
+    files = submission_files(submission_root)
+    RESULTS_PATH.write_text(json.dumps({"files": files, "total": len(files)}), encoding="utf-8")
+    POINTS_PATH.write_text("1\n", encoding="utf-8")
+
+    message = [f"Counted {len(files)} submitted file(s)."]
+    if files:
+        message.extend(f"  - {name}" for name in files)
+    else:
+        message.append("  (no files found)")
+
+    COMMENTS_PATH.write_text("\n".join(message) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/count-submitted-files/assets/main.sh
+++ b/examples/count-submitted-files/assets/main.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /workspace/assets/grader.py

--- a/examples/count-submitted-files/local-workspace/submission/README.md
+++ b/examples/count-submitted-files/local-workspace/submission/README.md
@@ -1,0 +1,1 @@
+# Example submission

--- a/examples/count-submitted-files/local-workspace/submission/__init__.py
+++ b/examples/count-submitted-files/local-workspace/submission/__init__.py
@@ -1,0 +1,1 @@
+"""Sample submission package for the checked-in example grader."""

--- a/examples/count-submitted-files/local-workspace/submission/main.py
+++ b/examples/count-submitted-files/local-workspace/submission/main.py
@@ -1,0 +1,6 @@
+"""Sample submission module for the checked-in example grader."""
+
+
+def greeting() -> str:
+    """Return a deterministic string for local sample files."""
+    return "hello from the sample submission"

--- a/examples/count-submitted-files/local-workspace/submission/nested/config.json
+++ b/examples/count-submitted-files/local-workspace/submission/nested/config.json
@@ -1,0 +1,3 @@
+{
+  "enabled": true
+}

--- a/tests/unit/test_repo_examples.py
+++ b/tests/unit/test_repo_examples.py
@@ -1,0 +1,14 @@
+"""Tests for checked-in repo examples."""
+
+from pathlib import Path
+
+
+def test_count_submitted_files_example_exists() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    example_root = repo_root / "examples" / "count-submitted-files"
+
+    assert (example_root / "README.md").exists()
+    assert (example_root / "assets" / "grader.py").exists()
+    assert (example_root / "assets" / "main.sh").exists()
+    assert (example_root / "local-workspace" / "submission" / "README.md").exists()
+    assert (example_root / "local-workspace" / "submission" / "main.py").exists()

--- a/tests/unit/test_repo_examples.py
+++ b/tests/unit/test_repo_examples.py
@@ -7,8 +7,8 @@ def test_count_submitted_files_example_exists() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     example_root = repo_root / "examples" / "count-submitted-files"
 
-    assert (example_root / "README.md").exists()
-    assert (example_root / "assets" / "grader.py").exists()
-    assert (example_root / "assets" / "main.sh").exists()
-    assert (example_root / "local-workspace" / "submission" / "README.md").exists()
-    assert (example_root / "local-workspace" / "submission" / "main.py").exists()
+    assert (example_root / "README.md").is_file()
+    assert (example_root / "assets" / "grader.py").is_file()
+    assert (example_root / "assets" / "main.sh").is_file()
+    assert (example_root / "local-workspace" / "submission" / "README.md").is_file()
+    assert (example_root / "local-workspace" / "submission" / "main.py").is_file()


### PR DESCRIPTION
## What changed
- added a checked-in `examples/count-submitted-files/` bundle at the repo root
- included grader assets plus a sample submission workspace so the docs example is available immediately on disk
- added a small regression test to ensure the example files stay present
- updated the README and grader docs to point to the checked-in example

## Why
The file-counting example described in the docs was useful for local testing, but it was not actually present in the repository. This change makes that example directly runnable without extra setup.

## Impact
Users can now go straight to `examples/count-submitted-files/` and try the documented sample grader locally or in Docker.

## Validation
- `uv run pytest tests/unit/test_repo_examples.py -q`
- `uv run ruff check examples/count-submitted-files/assets/grader.py examples/count-submitted-files/local-workspace/submission/__init__.py examples/count-submitted-files/local-workspace/submission/main.py tests/unit/test_repo_examples.py`
- `CCC_WORKSPACE_DIR=examples/count-submitted-files/local-workspace CCC_RESULTS_FILE=examples/count-submitted-files/local-workspace/results.json CCC_POINTS_FILE=examples/count-submitted-files/local-workspace/points.txt CCC_COMMENTS_FILE=examples/count-submitted-files/local-workspace/comments.txt python3 examples/count-submitted-files/assets/grader.py`

## Notes
- the unrelated local change in `docker-compose.yml` was left out of this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated course setup, CLI reference, and authoring guide to point to a ready-to-run example grader included in the repository and added a README for the example.

* **New Features**
  * Added a complete example grader with sample submission assets and local/Docker execution instructions to help test graders locally.

* **Tests**
  * Added a unit test that verifies the example grader directory and key example files are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->