### PR TITLE
fix(cli): align system list UX

### DIFF
--- a/src/canvas_code_correction/cli.py
+++ b/src/canvas_code_correction/cli.py
@@ -159,6 +159,20 @@ def system_status() -> None:
     )
 
 
+@system_app.command("list")
+def system_list() -> None:
+    """List saved course blocks.
+
+    Deprecated compatibility alias for `ccc course list`.
+    """
+    console.print("[yellow]`ccc system list` is deprecated; use `ccc course list`.[/yellow]")
+    cli_course_impl.course_list_command(
+        console=console,
+        find_course_block_names=find_course_block_names,
+        load_course_block=load_course_block,
+    )
+
+
 system_app.add_typer(webhook_app, name="webhook")
 system_app.add_typer(deploy_app, name="deploy")
 app.add_typer(course_app, name="course")

--- a/src/canvas_code_correction/cli.py
+++ b/src/canvas_code_correction/cli.py
@@ -159,20 +159,6 @@ def system_status() -> None:
     )
 
 
-@system_app.command("list")
-def system_list() -> None:
-    """List saved course blocks.
-
-    Deprecated compatibility alias for `ccc course list`.
-    """
-    console.print("[yellow]`ccc system list` is deprecated; use `ccc course list`.[/yellow]")
-    cli_course_impl.course_list_command(
-        console=console,
-        find_course_block_names=find_course_block_names,
-        load_course_block=load_course_block,
-    )
-
-
 system_app.add_typer(webhook_app, name="webhook")
 system_app.add_typer(deploy_app, name="deploy")
 app.add_typer(course_app, name="course")

--- a/src/canvas_code_correction/cli_system.py
+++ b/src/canvas_code_correction/cli_system.py
@@ -118,6 +118,4 @@ def system_status_command(
         else:
             console.print("[green]✓ RustFS (S3): Running[/green]")
 
-    console.print("\n[dim]Next steps:[/dim]")
-    console.print("[dim]  • Use 'ccc system --help' to see platform commands[/dim]")
-    console.print("[dim]  • Use 'ccc course list' to see saved courses[/dim]")
+    console.print("\n[dim]Use 'ccc system --help' to see platform commands[/dim]")

--- a/src/canvas_code_correction/cli_system.py
+++ b/src/canvas_code_correction/cli_system.py
@@ -118,4 +118,6 @@ def system_status_command(
         else:
             console.print("[green]✓ RustFS (S3): Running[/green]")
 
-    console.print("\n[dim]Use 'ccc course list' to see saved courses[/dim]")
+    console.print("\n[dim]Next steps:[/dim]")
+    console.print("[dim]  • Use 'ccc system --help' to see platform commands[/dim]")
+    console.print("[dim]  • Use 'ccc course list' to see saved courses[/dim]")

--- a/tests/unit/test_cli_structure.py
+++ b/tests/unit/test_cli_structure.py
@@ -49,7 +49,6 @@ class TestCLICommandStructure:
         assert "webhook" in result.output
         assert "deploy" in result.output
         assert "status" in result.output
-        assert "list" in result.output
 
     def test_webhook_help_shows_serve(self, cli_runner: CliRunner) -> None:
         """Test that webhook subcommand shows serve."""
@@ -104,19 +103,14 @@ class TestCLINoDevStackRequired:
         assert "Prefect server" in result.output
         assert "RustFS (S3)" in result.output
         assert "ccc system --help" in result.output
-        assert "ccc course list" in result.output
 
     @pytest.mark.local
-    def test_system_list_alias_shows_courses(self, cli_runner: CliRunner) -> None:
-        """Test compatibility alias for listing saved courses."""
-        with patch("canvas_code_correction.cli.find_course_block_names") as mock_find_course_blocks:
-            mock_find_course_blocks.return_value = []
+    def test_system_list_command_removed(self, cli_runner: CliRunner) -> None:
+        """Test system list is not an available command."""
+        result = cli_runner.invoke(app, ["system", "list"])
 
-            result = cli_runner.invoke(app, ["system", "list"])
-
-            assert result.exit_code == 0
-            assert "`ccc system list` is deprecated" in result.output
-            assert "No course configuration blocks found" in result.output
+        assert result.exit_code != 0
+        assert "No such command 'list'" in result.output
 
 
 class TestCLILegacyCommandMapping:

--- a/tests/unit/test_cli_structure.py
+++ b/tests/unit/test_cli_structure.py
@@ -49,6 +49,7 @@ class TestCLICommandStructure:
         assert "webhook" in result.output
         assert "deploy" in result.output
         assert "status" in result.output
+        assert "list" in result.output
 
     def test_webhook_help_shows_serve(self, cli_runner: CliRunner) -> None:
         """Test that webhook subcommand shows serve."""
@@ -102,6 +103,20 @@ class TestCLINoDevStackRequired:
         assert "Platform Status" in result.output
         assert "Prefect server" in result.output
         assert "RustFS (S3)" in result.output
+        assert "ccc system --help" in result.output
+        assert "ccc course list" in result.output
+
+    @pytest.mark.local
+    def test_system_list_alias_shows_courses(self, cli_runner: CliRunner) -> None:
+        """Test compatibility alias for listing saved courses."""
+        with patch("canvas_code_correction.cli.find_course_block_names") as mock_find_course_blocks:
+            mock_find_course_blocks.return_value = []
+
+            result = cli_runner.invoke(app, ["system", "list"])
+
+            assert result.exit_code == 0
+            assert "`ccc system list` is deprecated" in result.output
+            assert "No course configuration blocks found" in result.output
 
 
 class TestCLILegacyCommandMapping:


### PR DESCRIPTION
## Summary
- add a `ccc system list` compatibility alias that forwards to `ccc course list`
- make `ccc system status` advertise valid next steps without implying the wrong namespace
- cover the alias and updated status footer in CLI tests

## Verification
- `uv run pytest tests/unit/test_cli_structure.py -q`
- `python -m compileall src/canvas_code_correction/cli.py src/canvas_code_correction/cli_system.py`

## Notes
The integration-marked status tests in `tests/unit/test_cli_live_integration.py` are deselected by the repo's default pytest marker config unless run with integration markers enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ccc system list` command with a deprecation notice to support user migration paths.

* **Improvements**
  * Enhanced post-execution guidance with expanded next steps, including instructions for accessing help documentation and listing saved courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->