### PR TITLE
feat(dev): add Live Events Compose profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,25 @@
 CANVAS_API_URL=https://canvas.instructure.com
 CANVAS_API_TOKEN=your_canvas_api_token_here
 CANVAS_COURSE_ID=123456
+CANVAS_TEST_ASSIGNMENT_ID=59160606
 
 # Docker Compose Database Configuration (use .env.dev for local development)
 POSTGRES_PASSWORD=your_secure_postgres_password_here
 
-# Optional overrides
+# Local Compose overrides used by the dev-webhook profile
 CCC_WORKING_DIR=/tmp/ccc/runs
 CCC_WORKSPACE_ROOT=/tmp/ccc/workspaces
+CCC_WORK_POOL_NAME=local-pool
+CCC_COURSE_SLUG=cs101
+CCC_WEBHOOK_PUBLIC_URL=https://ccc-dev.example.com
+# Keep Canvas mutations disabled for tunnel smoke tests.
+CCC_WEBHOOK_DRY_RUN=true
+# Set true as a separate acknowledgement before enabling live Canvas writes.
+CCC_ALLOW_LIVE_CANVAS_WRITES=false
+
+# Remotely managed named Cloudflare Tunnel. Configure its public hostname to
+# route to http://webhook-listener:8080 on the Compose network.
+CLOUDFLARE_TUNNEL_TOKEN=your_cloudflare_tunnel_token_here
 
 # RustFS Configuration (for local development and testing)
 # Uncomment and adjust if using local RustFS server
@@ -21,9 +33,6 @@ CCC_WORKSPACE_ROOT=/tmp/ccc/workspaces
 # Prefect Configuration
 PREFECT_API_URL=http://localhost:4200/api
 PREFECT_API_KEY=your_prefect_api_key_here
-
-# Test Assignment ID (for integration tests)
-CANVAS_TEST_ASSIGNMENT_ID=59160606
 
 # Asset Storage Configuration (for production)
 # CCC_ASSETS_S3_ENDPOINT=https://s3.amazonaws.com

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ PREFECT_API_URL=http://localhost:4200/api
 For local RustFS testing, uncomment the `RUSTFS_*` entries in `.env.example` or
 use `.env.dev`.
 
+For a complete local stack that accepts real Canvas Live Events through a
+stable HTTPS address, use the named Cloudflare Tunnel workflow in
+[Testing Canvas Live Events Locally](docs/platform-setup/08-local-live-events.md).
+The stack reads `.env.dev`, verifies Canvas signed payloads, and keeps Canvas
+writes in dry-run mode by default.
+
 ## Development Commands
 
 The repo standard commands live in `pyproject.toml`:
@@ -167,6 +173,25 @@ $ poe prefect
 $ poe s3
 $ poe rustfs-setup
 $ uv run zensical build --strict --clean
+```
+
+Local Live Events stack:
+
+```bash
+$ poe dev-stack-config
+$ poe dev-stack-up
+$ poe dev-stack-status
+$ poe dev-stack-logs
+$ poe dev-stack-smoke
+$ poe dev-stack-down
+```
+
+These aliases use the `dev-webhook` Docker Compose profile directly. The
+Compose file is local-development infrastructure; production deployment is
+managed separately. To start the same profile without Poe:
+
+```bash
+$ docker compose --env-file .env.dev --profile dev-webhook up --build --wait -d
 ```
 
 Integration and e2e commands:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,25 +75,147 @@ services:
       PREFECT_REDIS_MESSAGING_PORT: 6379
       PREFECT_REDIS_MESSAGING_DB: 0
     command: prefect server services start
+  dev-init:
+    build: .
+    profiles: [dev-webhook]
+    depends_on:
+      prefect-server:
+        condition: service_healthy
+      rustfs:
+        condition: service_started
+    environment:
+      PREFECT_API_URL: http://prefect-server:4200/api
+      RUSTFS_ENDPOINT: http://rustfs:9000
+    env_file: [.env.dev]
+    entrypoint: [/bin/sh, -euc]
+    command:
+      - |
+        : "$${CANVAS_API_URL:?Set CANVAS_API_URL in .env.dev}"
+        : "$${CANVAS_API_TOKEN:?Set CANVAS_API_TOKEN in .env.dev}"
+        : "$${CANVAS_COURSE_ID:?Set CANVAS_COURSE_ID in .env.dev}"
+        : "$${CANVAS_TEST_ASSIGNMENT_ID:?Set CANVAS_TEST_ASSIGNMENT_ID in .env.dev}"
+        : "$${CCC_COURSE_SLUG:?Set CCC_COURSE_SLUG in .env.dev}"
+        : "$${CCC_WORKSPACE_ROOT:?Set CCC_WORKSPACE_ROOT in .env.dev}"
+        : "$${CCC_WEBHOOK_PUBLIC_URL:?Set CCC_WEBHOOK_PUBLIC_URL in .env.dev}"
+        : "$${CCC_WEBHOOK_DRY_RUN:?Set CCC_WEBHOOK_DRY_RUN in .env.dev}"
+        : "$${CLOUDFLARE_TUNNEL_TOKEN:?Set CLOUDFLARE_TUNNEL_TOKEN in .env.dev}"
+        public_host="$${CCC_WEBHOOK_PUBLIC_URL#https://}"
+        case "$$CCC_WEBHOOK_PUBLIC_URL:$$public_host" in
+          https://*:""|https://*:*/*)
+            echo "CCC_WEBHOOK_PUBLIC_URL must be an HTTPS origin without a path" >&2
+            exit 1
+            ;;
+          https://*:*) ;;
+          *)
+            echo "CCC_WEBHOOK_PUBLIC_URL must be an HTTPS origin without a path" >&2
+            exit 1
+            ;;
+        esac
+        case "$$CCC_WORKSPACE_ROOT" in
+          /*) ;;
+          *)
+            echo "CCC_WORKSPACE_ROOT must be an absolute path" >&2
+            exit 1
+            ;;
+        esac
+        case "$$CCC_WEBHOOK_DRY_RUN" in
+          true) ;;
+          false)
+            if [ "$${CCC_ALLOW_LIVE_CANVAS_WRITES:-false}" != true ]; then
+              echo "Live Canvas writes require CCC_ALLOW_LIVE_CANVAS_WRITES=true" >&2
+              exit 1
+            fi
+            ;;
+          *)
+            echo "CCC_WEBHOOK_DRY_RUN must be true or false" >&2
+            exit 1
+            ;;
+        esac
+        attempt=0
+        until python scripts/setup_rustfs.py; do
+          attempt=$$((attempt + 1))
+          if [ "$$attempt" -ge 12 ]; then
+            echo "RustFS setup did not become ready within 60 seconds" >&2
+            exit 1
+          fi
+          sleep 5
+        done
+        pool="$${CCC_WORK_POOL_NAME:-local-pool}"
+        slug="$$CCC_COURSE_SLUG"
+        prefix="$${RUSTFS_PREFIX:-dev}"
+        jwks_url="$${CANVAS_LIVE_EVENTS_JWKS_URL:-https://8axpcl50e4.execute-api.us-east-1.amazonaws.com/main/jwks}"
+        prefect work-pool create --type process --overwrite "$$pool"
+        printf %s "$$CANVAS_API_TOKEN" | ccc course setup \
+          --token-stdin \
+          --api-url "$$CANVAS_API_URL" \
+          --course-id "$$CANVAS_COURSE_ID" \
+          --no-interactive \
+          --assets-block local-rustfs \
+          --slug "$$slug" \
+          --assets-prefix "$$prefix" \
+          --work-pool "$$pool" \
+          --webhook-auth canvas-signed-jwt \
+          --webhook-jwks-url "$$jwks_url"
+        ccc system deploy create "ccc-course-$$slug"
+        echo "Development webhook resources are ready."
+        echo "Prefect UI: http://127.0.0.1:4200"
+        echo "Canvas callback: $${CCC_WEBHOOK_PUBLIC_URL%/}/webhooks/canvas/ccc-course-$$slug"
+        echo "Canvas writes: $$CCC_WEBHOOK_DRY_RUN"
   prefect-worker:
-    image: prefecthq/prefect:3-latest
+    build: .
+    profiles: [dev-webhook]
+    # Docker socket access grants host-level privileges; this stack is for trusted local use.
+    user: root
     depends_on:
-      prefect-server:
-        condition: service_healthy
+      dev-init:
+        condition: service_completed_successfully
     environment:
       PREFECT_API_URL: http://prefect-server:4200/api
-    command: prefect worker start --pool local-pool
+      RUSTFS_ENDPOINT: http://rustfs:9000
+    env_file: [.env.dev]
+    entrypoint: []
+    command: prefect worker start --pool ${CCC_WORK_POOL_NAME:-local-pool} --type
+      process
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CCC_WORKSPACE_ROOT:-/tmp/ccc/workspaces}:${CCC_WORKSPACE_ROOT:-/tmp/ccc/workspaces}
+    restart: unless-stopped
   webhook-listener:
-    image: prefecthq/prefect:3-latest
+    build: .
+    profiles: [dev-webhook]
     depends_on:
-      prefect-server:
-        condition: service_healthy
+      dev-init:
+        condition: service_completed_successfully
     environment:
       PREFECT_API_URL: http://prefect-server:4200/api
-    volumes: [.:/opt/canvas-code-correction]
-    working_dir: /opt/canvas-code-correction
-    command: sh -c "pip install -e . && ccc webhook serve --host 0.0.0.0 --port 8080"
+      RUSTFS_ENDPOINT: http://rustfs:9000
+    env_file: [.env.dev]
+    entrypoint: []
+    command: ccc system webhook serve --host 0.0.0.0 --port 8080
     ports: [8080:8080]
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health',
+          timeout=5)
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    profiles: [dev-webhook]
+    depends_on:
+      webhook-listener:
+        condition: service_healthy
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN?Set CLOUDFLARE_TUNNEL_TOKEN in .env.dev}
+    command: tunnel --no-autoupdate --metrics 0.0.0.0:2000 run
+    expose: [2000]
+    restart: unless-stopped
   rustfs:
     image: rustfs/rustfs:latest
     ports: [9000:9000, 9001:9001]

--- a/docs/current-development/01-roadmap.md
+++ b/docs/current-development/01-roadmap.md
@@ -26,7 +26,7 @@ The table below shows the completed milestones and their current state.
 | **Phase 1.5 – Test/Dev Environment**  | ✅ Complete | Shared Canvas cloud course (`https://canvas.instructure.com/courses/13121974`) for validation             | Enables rapid iteration without affecting production courses                                                |
 | **Phase 2 – Canvas Client Migration** | ✅ Complete | Canvas client, workspace store, Docker runner, result collector, uploader tasks, end‑to‑end Prefect flow  | All components implemented and tested; see the [migration plan](./02-phase-2-migration-plan.md) for details |
 | **Phase 3 – Container Runner**        | ✅ Complete | Docker execution with resource limits, smoke tests                                                        | Runner hardened for security and resource isolation                                                         |
-| **Phase 4 – Webhooks & Queueing**     | ✅ Complete | FastAPI webhook receiver with JWT validation, rate limiting, Prefect deployments, optional external queue | Production‑ready webhook handling                                                                           |
+| **Phase 4 – Webhooks & Queueing**     | 🟡 Core complete | FastAPI receiver, Canvas signed-payload validation, rate limiting, duplicate suppression, and Prefect deployments | Local tunnel workflow is available; production operations and any external queue remain separate work |
 | **Phase 5 – Reporting & Docs**        | ✅ Complete | Automated run summaries, expanded MkDocs content, GitHub Actions CI                                       | Documentation and reporting fully integrated into the CI/CD pipeline                                        |
 
 ## What’s Next

--- a/docs/platform-setup/03-scheduling-corrections.md
+++ b/docs/platform-setup/03-scheduling-corrections.md
@@ -37,7 +37,9 @@ Use this when you want the normal production flow.
    $ uv run prefect worker start --pool course-work-pool-cs101
    ```
 
-4. Configure Canvas to send submission events to the webhook server.
+4. Configure Canvas to send signed submission events to the webhook server.
+   For local testing through a public HTTPS tunnel, follow
+   [Testing Canvas Live Events Locally](08-local-live-events.md).
 
 ### 2. Manual backfills
 
@@ -86,6 +88,11 @@ For the standard automatic path, confirm:
 - the Prefect deployment exists
 - a worker is online for the course work pool
 - the course block points at the correct work pool and assets
+- Canvas Live Events has **Sign Payload** enabled
+
+Canvas Live Events signs the JWT request body with Canvas-managed rotating
+keys. It does not use CCC's legacy shared HMAC or bearer-JWT secret. CCC verifies
+the body against the configured Canvas JWK set before validating the event.
 
 ## Next Steps
 

--- a/docs/platform-setup/08-local-live-events.md
+++ b/docs/platform-setup/08-local-live-events.md
@@ -1,0 +1,194 @@
+# Testing Canvas Live Events Locally
+
+Use the development stack when Canvas must deliver real submission events to
+CCC running on your machine. Canvas requires a public HTTPS endpoint, so the
+stack includes a **named, remotely managed Cloudflare Tunnel**. The hostname is
+stable across restarts; unlike an ephemeral tunnel, it does not require the
+Canvas subscription to be edited each time.
+
+The request path is:
+
+```text
+Canvas Live Events
+  -> https://ccc-dev.example.edu/webhooks/canvas/ccc-course-cs101
+  -> Cloudflare Tunnel
+  -> webhook-listener:8080
+  -> Prefect deployment and worker
+  -> Docker grader
+  -> Canvas uploader (dry-run by default)
+```
+
+## Prerequisites
+
+- Docker with Compose support
+- a development Canvas course and API token
+- Canvas account-level access to Data Services / Live Events
+- a remotely managed named Cloudflare Tunnel and public hostname
+
+Create the tunnel and hostname in Cloudflare before starting CCC. Configure
+the public-hostname service to route to:
+
+```text
+http://webhook-listener:8080
+```
+
+Do not put Cloudflare Access authentication in front of this hostname: Canvas
+must be able to POST events directly. CCC authenticates signed Canvas payloads.
+
+## Configure `.env.dev`
+
+Keep all local secrets in the ignored `.env.dev` file. Add the following names
+using values for your environment; never commit or paste their values into
+logs or issue reports:
+
+```dotenv
+CLOUDFLARE_TUNNEL_TOKEN=
+CCC_WEBHOOK_PUBLIC_URL=
+CCC_COURSE_SLUG=
+CANVAS_LIVE_EVENTS_JWKS_URL=
+CCC_WEBHOOK_DRY_RUN=true
+
+CANVAS_API_URL=
+CANVAS_API_TOKEN=
+CANVAS_COURSE_ID=
+CANVAS_TEST_ASSIGNMENT_ID=
+
+CCC_WORKSPACE_ROOT=
+CCC_WORK_POOL_NAME=local-pool
+```
+
+`CCC_WEBHOOK_PUBLIC_URL` is the HTTPS origin only, with no trailing slash.
+`CCC_COURSE_SLUG` produces the block name `ccc-course-<slug>`. The Canvas JWK
+URL is optional when the built-in official endpoint is appropriate.
+
+The stack refuses live Canvas writes unless they are deliberately unlocked.
+Leave `CCC_WEBHOOK_DRY_RUN=true` for tunnel and event-delivery testing. An API
+token permits API reads; its presence does not itself enable grade or comment
+writes.
+
+## Start and inspect the stack
+
+`docker-compose.yml` is the repository's local-development stack. Production
+deployment is managed separately, so the optional Live Events services are
+selected with the `dev-webhook` profile instead of a Compose override file or
+host-side lifecycle script.
+
+Validate configuration before creating containers:
+
+```bash
+$ poe dev-stack-config
+```
+
+Start the services and provision the local RustFS block, Prefect work pool,
+course block, and deployment:
+
+```bash
+$ poe dev-stack-up
+```
+
+The profile runs a one-shot `dev-init` service before starting the worker and
+listener. Initialization is idempotent, and any validation or provisioning
+failure prevents the dependent services from starting. The equivalent direct
+command is:
+
+```bash
+$ docker compose --env-file .env.dev \
+    --profile dev-webhook \
+    up --build --wait -d
+```
+
+Inspect or follow the stack with:
+
+```bash
+$ poe dev-stack-status
+$ poe dev-stack-logs
+```
+
+To inspect provisioning specifically:
+
+```bash
+$ docker compose --env-file .env.dev \
+    --profile dev-webhook \
+    logs dev-init
+```
+
+Run the infrastructure smoke checks:
+
+```bash
+$ poe dev-stack-smoke
+```
+
+The smoke check verifies the local listener, public tunnel, Prefect API, work
+pool, and deployment. Signed-payload behavior is covered by the unit and
+integration suites; the real-event procedure below validates the complete
+Canvas delivery path without performing Canvas writes.
+
+## Configure Canvas Data Services
+
+In the Canvas account that owns the development course:
+
+1. Open **Data Services** and create a **Live Events** HTTPS stream.
+2. Choose the Canvas event format.
+3. Select `submission_created` and `submission_updated`.
+4. Enable **Sign Payload**.
+5. Use the callback assembled from `CCC_WEBHOOK_PUBLIC_URL` and
+   `CCC_COURSE_SLUG`, which has this form:
+
+   ```text
+   https://<public-host>/webhooks/canvas/ccc-course-<slug>
+   ```
+
+Canvas sends a compact signed JWT as the request body. CCC verifies that body
+against Canvas's rotating JWK set before it reads the event claims. A local
+HMAC secret or bearer token is not the signing mechanism for Canvas Live
+Events; those authentication modes remain only for compatibility and synthetic
+clients.
+
+Creating a stream requires Canvas Data Services permissions. A Canvas API key
+alone cannot create or replace that account-level configuration.
+
+## Exercise a real event safely
+
+Submit a file to the configured development assignment, then confirm:
+
+1. `poe dev-stack-logs` shows an accepted delivery without exposing its body.
+2. The listener returns `202 Accepted`.
+3. Prefect shows one flow run and an online worker picks it up.
+4. The grader completes and reports uploads as dry-run actions.
+5. Canvas receives no grade or comment.
+
+Canvas retries failed HTTPS deliveries. CCC uses the event/request identity to
+collapse retries so one delivery does not start several flow runs. Keep a
+non-2xx response visible while troubleshooting: it tells Canvas to retry after
+a transient JWK-fetch or Prefect handoff failure.
+
+## Troubleshooting
+
+- **Public health check fails:** confirm the Cloudflare hostname targets
+  `http://webhook-listener:8080`, the tunnel reports connected, and the listener
+  is healthy locally.
+- **Canvas gets 401:** confirm **Sign Payload** is enabled and the configured
+  JWK endpoint matches the Canvas environment. Do not add the API token as a
+  webhook bearer token.
+- **Canvas gets 502:** JWK retrieval or another authentication dependency is
+  unavailable. Restore connectivity and let Canvas retry.
+- **No Prefect run appears:** verify the deployment exists, the course slug in
+  the callback matches its block, and the worker is online for
+  `CCC_WORK_POOL_NAME`.
+- **The grader cannot see files:** `CCC_WORKSPACE_ROOT` must be absolute and
+  mounted at the same path in the worker and host Docker daemon.
+- **Containers use localhost URLs:** service-to-service settings must use
+  Compose names such as `prefect-server` and `rustfs`, not `localhost`.
+
+## Tear down
+
+Stop the stack when testing is complete:
+
+```bash
+$ poe dev-stack-down
+```
+
+Disable or delete the Canvas Live Events stream if the public endpoint will no
+longer be available. This prevents repeated failed deliveries. The named tunnel
+and hostname may remain configured for the next development session, but its
+token must remain only in `.env.dev`.

--- a/docs/reference/03-configuration.md
+++ b/docs/reference/03-configuration.md
@@ -139,6 +139,17 @@ fields:
 | --- | --- | --- |
 | `CCC_WORKSPACE_ROOT` | Override workspace root | `/tmp/ccc/workspaces` |
 
+### Local Live Events stack
+
+| Variable | Purpose |
+| --- | --- |
+| `CLOUDFLARE_TUNNEL_TOKEN` | Secret token for a remotely managed named tunnel |
+| `CCC_WEBHOOK_PUBLIC_URL` | Stable public HTTPS origin, without a trailing slash |
+| `CCC_COURSE_SLUG` | Slug used to select `ccc-course-<slug>` |
+| `CANVAS_LIVE_EVENTS_JWKS_URL` | Optional Canvas signing-key endpoint override |
+| `CCC_WEBHOOK_DRY_RUN` | Keep Canvas writes disabled; defaults to `true` |
+| `CCC_WORK_POOL_NAME` | Prefect worker pool; defaults to `local-pool` |
+
 ### RustFS / S3-compatible storage
 
 | Variable | Default | Purpose |
@@ -148,6 +159,9 @@ fields:
 | `RUSTFS_SECRET_KEY` | `rustfsadmin` | Secret key |
 | `RUSTFS_BUCKET_NAME` | `test-assets` | Bucket name |
 | `RUSTFS_PREFIX` | `dev` | Prefix used by `poe rustfs-setup` |
+
+See [Testing Canvas Live Events Locally](../platform-setup/08-local-live-events.md)
+for the complete `.env.dev`, tunnel, Canvas Data Services, and dry-run workflow.
 
 ## Common Errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,10 +89,31 @@ clean = {cmd = "uvx pyclean . --debris", help = "Clean up Python cache files and
 # Project-specific tasks
 docker-publish = {sequence = ["_docker_build", "_docker_push"], help = "Build and push docker image for base runner"}
 serve-docs = {cmd = "zensical serve", help = "Serve documentation locally."}
+dev-stack-config = {cmd = "docker compose --env-file .env.dev --profile dev-webhook config --quiet", help = "Validate the local Canvas webhook development stack configuration."}
+dev-stack-up = {cmd = "docker compose --env-file .env.dev --profile dev-webhook up --build --wait -d", help = "Start and provision the tunneled local Canvas webhook development stack."}
+dev-stack-status = {cmd = "docker compose --env-file .env.dev --profile dev-webhook ps", help = "Show the local Canvas webhook development stack status."}
+dev-stack-logs = {cmd = "docker compose --env-file .env.dev --profile dev-webhook logs --follow dev-init webhook-listener prefect-worker cloudflared", help = "Follow logs for the Canvas webhook development stack."}
+dev-stack-down = {cmd = "docker compose --env-file .env.dev --profile dev-webhook down", help = "Stop the local Canvas webhook development stack."}
 _docker_build.cmd = "docker build -t jakob1379/canvas-grader:latest . -f containers/grader/Dockerfile"
 _docker_push.cmd = "docker push jakob1379/canvas-grader:latest"
 _e2e_stack_up.cmd = "docker compose up --wait -d rustfs postgres redis prefect-server prefect-services"
 _test_e2e.cmd = "pytest -m e2e"
+dev-stack-smoke.shell = """
+set -eu
+set -a
+. ./.env.dev
+set +a
+curl --fail --silent --show-error http://127.0.0.1:8080/health >/dev/null
+curl --fail --silent --show-error "${CCC_WEBHOOK_PUBLIC_URL%/}/health" >/dev/null
+curl --fail --silent --show-error http://127.0.0.1:4200/api/health >/dev/null
+docker compose --env-file .env.dev --profile dev-webhook exec -T webhook-listener \
+  prefect work-pool inspect "${CCC_WORK_POOL_NAME:-local-pool}" >/dev/null
+docker compose --env-file .env.dev --profile dev-webhook exec -T webhook-listener \
+  prefect deployment inspect \
+  "webhook-correction-flow/ccc-${CCC_COURSE_SLUG}-deployment" >/dev/null
+echo "Development webhook stack is healthy."
+"""
+dev-stack-smoke.help = "Check local and public development stack health."
 generate-cli-docs.shell = "uv run typer src/canvas_code_correction/cli.py utils docs --title \"CLI Reference\" --name ccc --output 'docs/reference/02-cli.md'"
 prefect.shell = 'prefect server start'
 rustfs-setup.shell = "uv run python scripts/setup_rustfs.py"

--- a/tests/unit/test_dev_compose.py
+++ b/tests/unit/test_dev_compose.py
@@ -1,0 +1,113 @@
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+def _compose() -> dict[str, object]:
+    compose_path = Path(__file__).parents[2] / "docker-compose.yml"
+    return yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+
+
+def test_dev_webhook_profile_contains_complete_optional_stack() -> None:
+    services = _compose()["services"]
+
+    for service_name in ("dev-init", "prefect-worker", "webhook-listener", "cloudflared"):
+        assert services[service_name]["profiles"] == ["dev-webhook"]
+
+
+def test_dev_services_wait_for_successful_provisioning() -> None:
+    services = _compose()["services"]
+
+    for service_name in ("prefect-worker", "webhook-listener"):
+        assert services[service_name]["depends_on"]["dev-init"]["condition"] == (
+            "service_completed_successfully"
+        )
+    assert services["cloudflared"]["depends_on"]["webhook-listener"]["condition"] == (
+        "service_healthy"
+    )
+
+
+def test_dev_init_fails_closed_and_keeps_token_off_command_line() -> None:
+    init = _compose()["services"]["dev-init"]
+    command = init["command"][0]
+
+    assert "CCC_WEBHOOK_DRY_RUN" in command
+    assert "CCC_ALLOW_LIVE_CANVAS_WRITES" in command
+    assert "CCC_WEBHOOK_PUBLIC_URL must be an HTTPS origin" in command
+    assert 'printf %s "$$CANVAS_API_TOKEN"' in command
+    assert "--token-stdin" in command
+    assert "--token " not in command
+    assert "--webhook-auth canvas-signed-jwt" in command
+    assert "work-pool create --type process --overwrite" in command
+    assert "ccc system deploy create" in command
+
+
+def test_dev_init_rejects_missing_configuration_before_provisioning() -> None:
+    command = _compose()["services"]["dev-init"]["command"][0].replace("$$", "$")
+
+    result = subprocess.run(  # noqa: S603
+        ["/bin/sh", "-euc", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={},
+    )
+
+    assert result.returncode != 0
+    assert "CANVAS_API_URL" in result.stderr
+
+
+def test_dev_init_rejects_unacknowledged_live_writes() -> None:
+    command = _compose()["services"]["dev-init"]["command"][0].replace("$$", "$")
+    env = {
+        "CANVAS_API_URL": "https://canvas.example.edu",
+        "CANVAS_API_TOKEN": "secret",
+        "CANVAS_COURSE_ID": "123",
+        "CANVAS_TEST_ASSIGNMENT_ID": "456",
+        "CCC_COURSE_SLUG": "cs101",
+        "CCC_WORKSPACE_ROOT": "/tmp/ccc/workspaces",
+        "CCC_WEBHOOK_PUBLIC_URL": "https://ccc-dev.example.com",
+        "CCC_WEBHOOK_DRY_RUN": "false",
+        "CLOUDFLARE_TUNNEL_TOKEN": "secret",
+    }
+
+    result = subprocess.run(  # noqa: S603
+        ["/bin/sh", "-euc", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert "CCC_ALLOW_LIVE_CANVAS_WRITES=true" in result.stderr
+
+
+def test_dev_stack_uses_internal_endpoints_and_safe_tunnel_token() -> None:
+    services = _compose()["services"]
+
+    for service_name in ("dev-init", "prefect-worker", "webhook-listener"):
+        environment = services[service_name]["environment"]
+        assert environment["PREFECT_API_URL"] == "http://prefect-server:4200/api"
+        assert environment["RUSTFS_ENDPOINT"] == "http://rustfs:9000"
+
+    tunnel = services["cloudflared"]
+    assert "CLOUDFLARE_TUNNEL_TOKEN" in tunnel["environment"]["TUNNEL_TOKEN"]
+    assert "CLOUDFLARE_TUNNEL_TOKEN" not in tunnel["command"]
+
+
+def test_worker_retains_docker_socket_and_identical_workspace_mount() -> None:
+    worker = _compose()["services"]["prefect-worker"]
+    volumes = worker["volumes"]
+
+    assert "/var/run/docker.sock:/var/run/docker.sock" in volumes
+    assert any(
+        volume.count("${CCC_WORKSPACE_ROOT:-/tmp/ccc/workspaces}") == 2 for volume in volumes
+    )
+
+
+def test_host_orchestration_script_is_removed() -> None:
+    repo_root = Path(__file__).parents[2]
+
+    assert not (repo_root / "scripts" / "dev_stack.py").exists()

--- a/tests/unit/test_dev_compose.py
+++ b/tests/unit/test_dev_compose.py
@@ -66,7 +66,8 @@ def test_dev_init_rejects_unacknowledged_live_writes() -> None:
         "CANVAS_COURSE_ID": "123",
         "CANVAS_TEST_ASSIGNMENT_ID": "456",
         "CCC_COURSE_SLUG": "cs101",
-        "CCC_WORKSPACE_ROOT": "/tmp/ccc/workspaces",
+        # Test-only path; production deployment is outside this Compose configuration.
+        "CCC_WORKSPACE_ROOT": "/tmp/ccc/workspaces",  # NOSONAR
         "CCC_WEBHOOK_PUBLIC_URL": "https://ccc-dev.example.com",
         "CCC_WEBHOOK_DRY_RUN": "false",
         "CLOUDFLARE_TUNNEL_TOKEN": "secret",
@@ -89,8 +90,9 @@ def test_dev_stack_uses_internal_endpoints_and_safe_tunnel_token() -> None:
 
     for service_name in ("dev-init", "prefect-worker", "webhook-listener"):
         environment = services[service_name]["environment"]
-        assert environment["PREFECT_API_URL"] == "http://prefect-server:4200/api"
-        assert environment["RUSTFS_ENDPOINT"] == "http://rustfs:9000"
+        # These endpoints stay on the private Compose network; TLS terminates externally.
+        assert environment["PREFECT_API_URL"] == "http://prefect-server:4200/api"  # NOSONAR
+        assert environment["RUSTFS_ENDPOINT"] == "http://rustfs:9000"  # NOSONAR
 
     tunnel = services["cloudflared"]
     assert "CLOUDFLARE_TUNNEL_TOKEN" in tunnel["environment"]["TUNNEL_TOKEN"]


### PR DESCRIPTION
## Summary

- add a dev-webhook Compose profile for initialization, worker, listener, and Cloudflare Tunnel services
- provision RustFS, the Prefect work pool, signed-JWT course block, and webhook deployment through a fail-closed one-shot dev-init service
- keep tokens off command arguments and require explicit acknowledgement before live Canvas writes
- retain the existing Poe command names as direct Compose and health-check commands
- document direct Compose usage and state explicitly that production deployment is outside this Compose file

## Stack

This is layer 3 of 3. It depends on #154, which depends on #153.

## Checks

- uv run pytest tests/unit -q --strict-markers
- uv run pytest tests/integration/webhooks -q --strict-markers -m integration --no-cov
- uv run ruff format --check .
- uv run ruff check .
- uv run pyrefly check src
- uv run zensical build --clean
- docker compose --env-file .env.dev --profile dev-webhook config --quiet with placeholder tunnel settings
- commit hooks

## Local limitation

The live tunnel itself still requires a named Cloudflare Tunnel token and hostname in the ignored .env.dev file.

---

## Review findings

Multi-agent review (4 independent reviewers) — full detail in [this comment](https://github.com/jakob1379/Canvas-Code-Correction/pull/152#issuecomment-5301956229). Verdicts: approve-with-nits / block / block; the blocks carry executed evidence.

Note this PR fixes a genuinely broken base: at `b9152113`, `webhook-listener` ran `ccc webhook serve`, a command that does not exist.

**Critical**

- [ ] Untrack `.env.dev` — it is git-tracked (`git ls-files --error-unmatch .env.dev` succeeds; `.gitignore:5` has no effect on already-tracked files) while `08-local-live-events.md:40,:194` instructs users to keep the Cloudflare tunnel token and Canvas token in it as "the ignored `.env.dev` file". No credentials have leaked — all tracked secret-shaped values are placeholders/dummies — but following the doc puts live tokens into a tracked file in a public repo. Fix: `git rm --cached .env.dev`, ship `.env.dev.example`, update the doc

**Important**

- [ ] Scope the tunnel-token interpolation — `docker-compose.yml:215` `${CLOUDFLARE_TUNNEL_TOKEN?...}` is evaluated for the whole file regardless of profile. Verified: `POSTGRES_PASSWORD=x docker compose config rustfs postgres redis prefect-server -q` → exit 1 at HEAD, exit 0 at `b9152113`. This breaks `poe test-e2e` (`_e2e_stack_up` passes no `--env-file`) for anyone whose `.env` predates this PR. Use `${CLOUDFLARE_TUNNEL_TOKEN:-}` or give `cloudflared` the `env_file` its siblings have
- [ ] Resolve `CCC_WORKSPACE_ROOT` — required, absolute-validated, mounted, documented and troubleshot, but read by no source file. The worker uses the block value (`config.py:21-22`, always `/tmp/ccc/workspaces`); set it to anything else and the grader mounts an empty dir. Wire it (`--workspace-root`) or delete it and hardcode the mount
- [ ] Close the `setup_rustfs.py` fail-open — `main()` returns **0** when `register_prefect_block()` fails (`:238-258`), so `dev-init` reports "resources are ready" with a course block pointing at a nonexistent S3 block; it surfaces at `workspace.py:105` during the first real run. Add `prefect block inspect s3-bucket/local-rustfs` after the loop, or return 1
- [ ] Fix the slug mismatch — `cli_course.py:625` slugifies `--slug`, but `docker-compose.yml:159` runs `deploy create "ccc-course-$$slug"` raw. `CCC_COURSE_SLUG=CS_101` creates `ccc-course-cs-101` then fails to load `ccc-course-CS_101`; the `cs101` default masks it
- [ ] Correct `CCC_WEBHOOK_DRY_RUN` in `docs/reference/03-configuration.md:150` — the table says "defaults to `true`", the code defaults to `false` (live writes). Wrong in the unsafe direction (see #154)
- [ ] Document `CCC_ALLOW_LIVE_CANVAS_WRITES` — the headline write-safety gate is described in prose ("deliberately unlocked") but never named, absent from the `.env.dev` template and the config table, and lives only in `.env.example:19`, which this profile never reads
- [ ] Make `poe dev-stack-config` work on a fresh clone — the new required vars went into `.env.example`, but every Poe task and `env_file:` reads `.env.dev`, so the first documented step exits 1 on interpolation before `dev-init` can give an actionable error
- [ ] Fix or reword the end-to-end doc — `08-local-live-events.md:150-158` promises "the grader completes and reports uploads as dry-run actions", but `setup_rustfs.py:144-149` uploads only `dev/test.txt` and the grader's default command is `sh /workspace/assets/main.sh` (`config.py:46`), which does not exist
- [ ] Drop the `CANVAS_TEST_ASSIGNMENT_ID` guard — `docker-compose.yml:96` blocks the whole profile on a pytest-only variable nothing in the stack reads

**Minor**

- [ ] Bind the listener to localhost — `docker-compose.yml:195` `8080:8080` publishes on `0.0.0.0`; `cloudflared` uses the Compose network, so the publish exists only for the smoke curl. Contradicts the "private endpoints" framing of `744e57b` and `test_dev_compose.py:93`
- [ ] Add a `cloudflared` healthcheck against `http://127.0.0.1:2000/ready` — `up --wait` currently returns before the tunnel registers, so `dev-stack-smoke` 502s on a healthy stack; `--metrics` + `expose: [2000]` are otherwise dead config
- [ ] Make `restart:` policies consistent — only the three new services have `unless-stopped`; after a reboot cloudflared serves the hostname while the listener crash-loops against a down prefect-server, and Canvas retires the subscription
- [ ] Simplify the `case` URL validator and fix the "60 seconds" message (12 × `sleep 5` = 55 s plus script runtime); the trailing-slash rejection also makes the `%/` stripping at `:162` and `pyproject.toml:107` dead
- [ ] Stop hardcoding the JWKS URL at `:146` — `cli_course.py:448` already defaults to the `config.py:9` constant; three copies now exist
- [ ] `dev-stack-smoke` sources `.env.dev` with `. ./.env.dev` under `set -a` — shell sourcing, not dotenv parsing; `#`/`$`/backticks behave differently or execute
- [ ] Rename the `user: root` test to say "grants" not "retains" (the base worker had neither root nor the socket), and note workspace files end up root-owned on the host
- [ ] Drop `CCC_WORKING_DIR` from `.env.example:10-11` — read nowhere in the repo and never referenced by compose

**Tests**

- [ ] Cover the URL validator's accept path — the subtlest logic in the diff, and only its catch-all rejection is exercised; a refactor that rejects every valid origin kills the profile and the suite stays green (~4 lines with the `subprocess` pattern at `:49`)
- [ ] Delete `test_host_orchestration_script_is_removed` (`:112-115`) — `scripts/dev_stack.py` does not exist at the merge base or after, so the assertion is unconditionally true
- [ ] Prune the YAML-restatement tests — 6 of 8 (`:12-28,:31-43,:88-99,:102-109`) assert the file contains what it contains and pass whether or not the stack works; `assert "--token " not in command` also passes for `--token=$X`

~213 of the 522 added lines are removable without behaviour change, concentrated in `test_dev_compose.py` (~95), doc/alias triplication (~60), and preflight/smoke shell duplicating native Compose features (~45).
