### PR TITLE
feat(webhooks): verify Canvas signed events

### DIFF
--- a/docs/reference/01-architecture.md
+++ b/docs/reference/01-architecture.md
@@ -103,8 +103,8 @@ sequenceDiagram
 
 1. **Webhook trigger** – Canvas sends a `submission_created` or
    `submission_updated` payload to the FastAPI webhook server.
-2. **Validation** – The server rate limits the request, verifies the Canvas
-   signature, and validates the JSON payload.
+2. **Validation** – The server rate limits the request, verifies the signed JWT
+   body against Canvas's rotating JWK set, and then validates its event claims.
 3. **Deployment launch** – The webhook handler ensures the course deployment
    exists and starts `webhook_correction_flow` through Prefect.
 4. **Flow handoff** – `webhook_correction_flow` loads course settings and calls

--- a/docs/reference/03-configuration.md
+++ b/docs/reference/03-configuration.md
@@ -69,9 +69,17 @@ The runtime model itself lives in `src/canvas_code_correction/config.py`.
 - `secret`
 - `deployment_name`
 - `enabled`
+- `auth_mode`
+- `canvas_jwks_url`
+- `canvas_jwks_cache_seconds`
 - `require_jwt`
 - `rate_limit`
 - `allow_canvas_api_fallback`
+
+New course blocks use `canvas-signed-jwt`, which verifies the compact Canvas
+Live Events request body using Canvas-managed JWKs. `require_jwt` and the local
+webhook secret describe legacy bearer-JWT/HMAC clients; they are not the Canvas
+Live Events **Sign Payload** mechanism.
 
 ## Persisted Course Block Fields
 
@@ -87,8 +95,8 @@ fields:
 - `grader_image`
 - `work_pool_name`
 - `grader_env`
-- webhook fields such as `deployment_name`, `webhook_enabled`, and
-  `webhook_rate_limit`
+- webhook fields such as `deployment_name`, `webhook_enabled`,
+  `webhook_auth_mode`, `webhook_canvas_jwks_url`, and `webhook_rate_limit`
 
 ## CLI-to-Block Mapping
 
@@ -103,6 +111,9 @@ fields:
 | `--docker-image` | `grader_image` |
 | `--work-pool` | `work_pool_name` |
 | `--env` | `grader_env` |
+| `--webhook-auth` | `webhook_auth_mode` |
+| `--webhook-jwks-url` | `webhook_canvas_jwks_url` |
+| `--webhook-rate-limit` | `webhook_rate_limit` |
 
 ## Environment Variables
 
@@ -137,13 +148,6 @@ fields:
 | `RUSTFS_SECRET_KEY` | `rustfsadmin` | Secret key |
 | `RUSTFS_BUCKET_NAME` | `test-assets` | Bucket name |
 | `RUSTFS_PREFIX` | `dev` | Prefix used by `poe rustfs-setup` |
-
-## Known Gap
-
-`allow_canvas_api_fallback` exists in the runtime `WebhookSettings` model, but
-it is **not** currently exposed by `ccc course setup` or persisted on the
-course block. Treat it as an internal runtime field unless that persistence path
-is added.
 
 ## Common Errors
 

--- a/src/canvas_code_correction/bootstrap.py
+++ b/src/canvas_code_correction/bootstrap.py
@@ -89,5 +89,21 @@ def load_settings_from_course_block(block_name: str) -> Settings:
             enabled=block.webhook_enabled,
             require_jwt=block.webhook_require_jwt,
             rate_limit=block.webhook_rate_limit,
+            auth_mode=getattr(block, "webhook_auth_mode", None),
+            canvas_jwks_url=getattr(
+                block,
+                "webhook_canvas_jwks_url",
+                "https://8axpcl50e4.execute-api.us-east-1.amazonaws.com/main/jwks",
+            ),
+            canvas_jwks_cache_seconds=getattr(
+                block,
+                "webhook_canvas_jwks_cache_seconds",
+                3600,
+            ),
+            allow_canvas_api_fallback=getattr(
+                block,
+                "webhook_allow_canvas_api_fallback",
+                False,
+            ),
         ),
     )

--- a/src/canvas_code_correction/cli_course.py
+++ b/src/canvas_code_correction/cli_course.py
@@ -18,6 +18,11 @@ from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 from slugify import slugify
 
+from canvas_code_correction.config import (
+    CANVAS_LIVE_EVENTS_JWKS_URL,
+    WebhookAuthMode,
+)
+
 if TYPE_CHECKING:
     from canvasapi.course import Course
 
@@ -48,6 +53,10 @@ class CourseSetupConfig:
     docker_image: str
     test_map_count: int
     grader_env: dict[str, str]
+    webhook_auth_mode: WebhookAuthMode
+    webhook_canvas_jwks_url: str
+    webhook_rate_limit: str
+    webhook_enabled: bool
 
 
 @dataclass(frozen=True)
@@ -72,6 +81,10 @@ class CourseSetupOptions:
     slug: str | None
     assets_prefix: str | None
     work_pool: str | None
+    webhook_auth_mode: WebhookAuthMode
+    webhook_canvas_jwks_url: str
+    webhook_rate_limit: str
+    webhook_enabled: bool
 
 
 class CourseConfigBlockPayload(TypedDict):
@@ -83,6 +96,10 @@ class CourseConfigBlockPayload(TypedDict):
     grader_image: str
     work_pool_name: str
     grader_env: dict[str, str]
+    webhook_auth_mode: WebhookAuthMode
+    webhook_canvas_jwks_url: HttpUrl
+    webhook_rate_limit: str
+    webhook_enabled: bool
 
 
 def _run_cli_step[T](console, step: str, action: Callable[[], T]) -> T:
@@ -421,6 +438,17 @@ def _parse_course_setup_options(args: list[str], *, console) -> CourseSetupOptio
     parser.add_argument("--slug", default=None)
     parser.add_argument("--assets-prefix", default=None)
     parser.add_argument("--work-pool", default=None)
+    parser.add_argument(
+        "--webhook-auth",
+        choices=[mode.value for mode in WebhookAuthMode],
+        default=WebhookAuthMode.CANVAS_SIGNED_JWT.value,
+    )
+    parser.add_argument(
+        "--webhook-jwks-url",
+        default=CANVAS_LIVE_EVENTS_JWKS_URL,
+    )
+    parser.add_argument("--webhook-rate-limit", default="10/minute")
+    parser.add_argument("--webhook-disabled", action="store_true")
 
     parsed, unknown_args = parser.parse_known_args(args)
     if unknown_args:
@@ -440,6 +468,10 @@ def _parse_course_setup_options(args: list[str], *, console) -> CourseSetupOptio
         slug=parsed.slug or None,
         assets_prefix=parsed.assets_prefix or None,
         work_pool=parsed.work_pool or None,
+        webhook_auth_mode=WebhookAuthMode(parsed.webhook_auth),
+        webhook_canvas_jwks_url=parsed.webhook_jwks_url,
+        webhook_rate_limit=parsed.webhook_rate_limit,
+        webhook_enabled=not parsed.webhook_disabled,
     )
 
 
@@ -654,6 +686,10 @@ def _build_course_setup_config(
         docker_image=resolved_docker_image,
         test_map_count=len(test_map_env),
         grader_env=grader_env,
+        webhook_auth_mode=options.webhook_auth_mode,
+        webhook_canvas_jwks_url=options.webhook_canvas_jwks_url,
+        webhook_rate_limit=options.webhook_rate_limit,
+        webhook_enabled=options.webhook_enabled,
     )
 
 
@@ -670,6 +706,8 @@ def _print_course_setup_summary(config: CourseSetupConfig, *, console) -> None:
     summary_table.add_row("Work Pool", config.work_pool)
     summary_table.add_row("Docker Image", config.docker_image)
     summary_table.add_row("Test Mappings", str(config.test_map_count))
+    summary_table.add_row("Webhook Auth", config.webhook_auth_mode.value)
+    summary_table.add_row("Webhook Enabled", str(config.webhook_enabled))
     console.print(summary_table)
 
 
@@ -683,6 +721,10 @@ def _build_course_block_payload(config: CourseSetupConfig) -> CourseConfigBlockP
         "grader_image": config.docker_image,
         "work_pool_name": config.work_pool,
         "grader_env": config.grader_env,
+        "webhook_auth_mode": config.webhook_auth_mode,
+        "webhook_canvas_jwks_url": HttpUrl(config.webhook_canvas_jwks_url),
+        "webhook_rate_limit": config.webhook_rate_limit,
+        "webhook_enabled": config.webhook_enabled,
     }
 
 
@@ -819,6 +861,10 @@ def course_setup_command(
             slug=options.slug,
             assets_prefix=options.assets_prefix,
             work_pool=options.work_pool,
+            webhook_auth_mode=options.webhook_auth_mode,
+            webhook_canvas_jwks_url=options.webhook_canvas_jwks_url,
+            webhook_rate_limit=options.webhook_rate_limit,
+            webhook_enabled=options.webhook_enabled,
         ),
         console=console,
         Prompt=Prompt,

--- a/src/canvas_code_correction/config.py
+++ b/src/canvas_code_correction/config.py
@@ -1,9 +1,21 @@
 """Configuration helpers for Canvas Code Correction."""
 
 import tempfile
+from enum import StrEnum
 from pathlib import Path
 
 from pydantic import BaseModel, Field, HttpUrl, SecretStr
+
+CANVAS_LIVE_EVENTS_JWKS_URL = "https://8axpcl50e4.execute-api.us-east-1.amazonaws.com/main/jwks"
+
+
+class WebhookAuthMode(StrEnum):
+    """Supported webhook authentication mechanisms."""
+
+    CANVAS_SIGNED_JWT = "canvas-signed-jwt"
+    HMAC = "hmac"
+    LEGACY_BEARER_JWT = "legacy-bearer-jwt"
+    CANVAS_API = "canvas-api"
 
 
 def _default_workspace_root() -> Path:
@@ -86,6 +98,24 @@ class WebhookSettings(BaseModel):
             "request authentication."
         ),
     )
+    auth_mode: WebhookAuthMode | None = Field(
+        default=None,
+        description="Explicit authentication mode; omitted preserves legacy configuration",
+    )
+    canvas_jwks_url: HttpUrl = Field(default=CANVAS_LIVE_EVENTS_JWKS_URL, validate_default=True)
+    canvas_jwks_cache_seconds: int = Field(default=3600, gt=0)
+
+    def effective_auth_mode(self) -> WebhookAuthMode | None:
+        """Resolve explicit mode or the equivalent legacy configuration."""
+        if self.auth_mode is not None:
+            return self.auth_mode
+        if self.require_jwt:
+            return WebhookAuthMode.LEGACY_BEARER_JWT
+        if self.secret is not None:
+            return WebhookAuthMode.HMAC
+        if self.allow_canvas_api_fallback:
+            return WebhookAuthMode.CANVAS_API
+        return None
 
 
 class Settings(BaseModel):

--- a/src/canvas_code_correction/prefect_blocks/canvas.py
+++ b/src/canvas_code_correction/prefect_blocks/canvas.py
@@ -3,6 +3,8 @@
 from prefect.blocks.core import Block
 from pydantic import Field, HttpUrl, SecretStr
 
+from canvas_code_correction.config import CANVAS_LIVE_EVENTS_JWKS_URL, WebhookAuthMode
+
 
 class CourseConfigBlock(Block):
     """Prefect block encapsulating per-course configuration."""
@@ -50,6 +52,16 @@ class CourseConfigBlock(Block):
         default="10/minute",
         description="Rate limit for webhook requests (e.g., '10/minute', '100/hour')",
     )
+    webhook_auth_mode: WebhookAuthMode | None = Field(
+        default=None,
+        description="Explicit webhook authentication mode",
+    )
+    webhook_canvas_jwks_url: HttpUrl = Field(
+        default=CANVAS_LIVE_EVENTS_JWKS_URL,
+        validate_default=True,
+    )
+    webhook_canvas_jwks_cache_seconds: int = Field(default=3600, gt=0)
+    webhook_allow_canvas_api_fallback: bool = False
 
 
 __all__ = ["CourseConfigBlock"]

--- a/src/canvas_code_correction/webhooks/auth.py
+++ b/src/canvas_code_correction/webhooks/auth.py
@@ -6,11 +6,12 @@ import hashlib
 import hmac
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import TYPE_CHECKING
+from time import monotonic
+from typing import TYPE_CHECKING, Any
 
 import jwt
 import requests
-from jwt.exceptions import InvalidTokenError
+from jwt.exceptions import InvalidTokenError, PyJWTError
 from pydantic import ValidationError
 
 if TYPE_CHECKING:
@@ -20,10 +21,68 @@ if TYPE_CHECKING:
 
     from canvas_code_correction.config import Settings
 
+from canvas_code_correction.config import WebhookAuthMode
 from canvas_code_correction.webhooks.models import (
     CanvasWebhookPayload,
     UnsupportedSubmissionEventError,
 )
+
+_ASYMMETRIC_JWT_ALGORITHMS = frozenset({"RS256", "RS384", "RS512", "ES256", "ES384", "ES512"})
+
+
+@dataclass
+class _CachedJwkSet:
+    keys: list[dict[str, Any]]
+    expires_at: float
+
+
+_jwk_cache: dict[str, _CachedJwkSet] = {}
+
+
+class _JwkSetUnavailableError(RuntimeError):
+    """Raised when no usable Canvas signing key set can be obtained."""
+
+
+def clear_jwk_cache() -> None:
+    """Clear the process-local JWK cache, primarily for tests."""
+    _jwk_cache.clear()
+
+
+def _fetch_jwks(url: str) -> list[dict[str, Any]]:
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    document = response.json()
+    keys = document.get("keys") if isinstance(document, dict) else None
+    if not isinstance(keys, list):
+        msg = "Canvas JWK endpoint returned an invalid key set"
+        raise TypeError(msg)
+    return [key for key in keys if isinstance(key, dict)]
+
+
+def _matching_jwk(
+    url: str,
+    kid: str,
+    cache_seconds: int,
+) -> dict[str, Any] | None:
+    cached = _jwk_cache.get(url)
+    now = monotonic()
+    if cached is not None and cached.expires_at > now:
+        match = next((key for key in cached.keys if key.get("kid") == kid), None)
+        if match is not None:
+            return match
+
+    old_match = None
+    if cached is not None:
+        old_match = next((key for key in cached.keys if key.get("kid") == kid), None)
+    try:
+        keys = _fetch_jwks(url)
+    except (requests.RequestException, TypeError, ValueError) as exc:
+        if old_match is not None:
+            return old_match
+        msg = "Canvas signing keys are unavailable"
+        raise _JwkSetUnavailableError(msg) from exc
+    _jwk_cache[url] = _CachedJwkSet(keys=keys, expires_at=now + cache_seconds)
+    return next((key for key in keys if key.get("kid") == kid), None)
 
 
 def _is_json_parse_error(error: ValidationError) -> bool:
@@ -137,6 +196,62 @@ class WebhookVerificationResult:
     message: str
     status_code: int
     mode: str
+    payload: CanvasWebhookPayload | None = None
+
+
+def _canvas_signed_jwt_verification_result(  # noqa: PLR0911
+    settings: Settings,
+    payload_body: bytes,
+) -> WebhookVerificationResult:
+    """Verify and decode a Canvas Live Events signed request body."""
+    invalid_result = WebhookVerificationResult(
+        success=False,
+        message="Invalid Canvas signed webhook payload",
+        status_code=HTTPStatus.UNAUTHORIZED.value,
+        mode=WebhookAuthMode.CANVAS_SIGNED_JWT.value,
+    )
+    try:
+        token = payload_body.decode("ascii").strip()
+        header = jwt.get_unverified_header(token)
+        kid = header.get("kid")
+        algorithm = header.get("alg")
+        if not isinstance(kid, str) or not kid:
+            return invalid_result
+        if not isinstance(algorithm, str) or algorithm not in _ASYMMETRIC_JWT_ALGORITHMS:
+            return invalid_result
+        jwk_data = _matching_jwk(
+            str(settings.webhook.canvas_jwks_url),
+            kid,
+            settings.webhook.canvas_jwks_cache_seconds,
+        )
+        if jwk_data is None:
+            return invalid_result
+        if jwk_data.get("alg") not in {None, algorithm}:
+            return invalid_result
+        key = jwt.PyJWK.from_dict(jwk_data, algorithm=algorithm).key
+        claims = jwt.decode(
+            token,
+            key,
+            algorithms=[algorithm],
+            options={"verify_exp": False},
+        )
+        payload = CanvasWebhookPayload.model_validate(claims)
+    except _JwkSetUnavailableError:
+        return WebhookVerificationResult(
+            success=False,
+            message="Canvas signing keys are temporarily unavailable",
+            status_code=HTTPStatus.BAD_GATEWAY.value,
+            mode=WebhookAuthMode.CANVAS_SIGNED_JWT.value,
+        )
+    except (UnicodeDecodeError, PyJWTError, ValidationError):
+        return invalid_result
+    return WebhookVerificationResult(
+        success=True,
+        message="Canvas signed JWT verification succeeded",
+        status_code=HTTPStatus.OK.value,
+        mode=WebhookAuthMode.CANVAS_SIGNED_JWT.value,
+        payload=payload,
+    )
 
 
 def validate_jwt_token(token: str, secret: SecretStr | None) -> bool:
@@ -256,13 +371,16 @@ def validate_canvas_signature(
     Otherwise, validates HMAC when a shared webhook secret is configured. Canvas
     API fallback is only allowed when explicitly enabled.
     """
-    if settings.webhook.require_jwt:
+    mode = settings.webhook.effective_auth_mode()
+    if mode is WebhookAuthMode.CANVAS_SIGNED_JWT:
+        return _canvas_signed_jwt_verification_result(settings, payload_body)
+    if mode is WebhookAuthMode.LEGACY_BEARER_JWT:
         return _jwt_verification_result(settings, headers)
 
-    if settings.webhook.secret is not None:
+    if mode is WebhookAuthMode.HMAC:
         return _hmac_verification_result(settings, payload_body, headers)
 
-    if not settings.webhook.allow_canvas_api_fallback:
+    if mode is not WebhookAuthMode.CANVAS_API:
         return WebhookVerificationResult(
             success=False,
             message=(

--- a/src/canvas_code_correction/webhooks/auth.py
+++ b/src/canvas_code_correction/webhooks/auth.py
@@ -212,7 +212,9 @@ def _canvas_signed_jwt_verification_result(  # noqa: PLR0911
     )
     try:
         token = payload_body.decode("ascii").strip()
-        header = jwt.get_unverified_header(token)
+        # Reading the header only selects an allow-listed algorithm and JWK; jwt.decode below
+        # verifies the signature before claims are accepted.
+        header = jwt.get_unverified_header(token)  # NOSONAR
         kid = header.get("kid")
         algorithm = header.get("alg")
         if not isinstance(kid, str) or not kid:

--- a/src/canvas_code_correction/webhooks/server.py
+++ b/src/canvas_code_correction/webhooks/server.py
@@ -17,7 +17,7 @@ from pydantic import ValidationError
 
 import canvas_code_correction.webhooks.handler as webhook_handler
 from canvas_code_correction.bootstrap import CourseBlockLoadError, load_settings_from_course_block
-from canvas_code_correction.config import Settings  # noqa: TC001
+from canvas_code_correction.config import Settings, WebhookAuthMode
 from canvas_code_correction.webhooks.auth import verify_canvas_webhook
 from canvas_code_correction.webhooks.deployments import trigger_deployment
 from canvas_code_correction.webhooks.models import CanvasWebhookPayload
@@ -217,6 +217,20 @@ async def validate_webhook(
 
     # Read raw body for signature verification
     body = await request.body()
+
+    if settings.webhook.effective_auth_mode() is WebhookAuthMode.CANVAS_SIGNED_JWT:
+        verification = verify_canvas_webhook(settings, body, dict(request.headers))
+        if not verification.success:
+            raise HTTPException(
+                status_code=verification.status_code,
+                detail=verification.message,
+            )
+        if verification.payload is None:  # Defensive: successful signed verification must decode.
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="Invalid Canvas signed webhook payload",
+            )
+        return verification.payload
 
     # Parse and validate JSON payload once
     try:

--- a/tests/integration/webhooks/test_webhook_integration.py
+++ b/tests/integration/webhooks/test_webhook_integration.py
@@ -196,18 +196,16 @@ def test_webhook_prefect_handoff_failure_returns_unsuccessful_response(
 
     mock_limiter = Mock()
     mock_limiter.hit.return_value = True
+    webhook_server.app.dependency_overrides[webhook_server.get_rate_limiter] = lambda: mock_limiter
     try:
-        with patch(
-            "canvas_code_correction.webhooks.server.get_rate_limiter",
-            return_value=mock_limiter,
-        ):
-            response = client.post(
-                "/webhooks/canvas/test-course",
-                json=payload,
-                headers=headers,
-            )
+        response = client.post(
+            "/webhooks/canvas/test-course",
+            json=payload,
+            headers=headers,
+        )
     finally:
         webhook_server.app.dependency_overrides.pop(webhook_server.get_webhook_runner, None)
+        webhook_server.app.dependency_overrides.pop(webhook_server.get_rate_limiter, None)
 
     assert response.status_code == 502
     body = response.json()

--- a/tests/integration/webhooks/test_webhook_signals.py
+++ b/tests/integration/webhooks/test_webhook_signals.py
@@ -158,9 +158,9 @@ def test_webhook_unsupported_event_type(
     finally:
         webhook_server.app.dependency_overrides.pop(webhook_server.get_webhook_runner, None)
 
-    assert response.status_code == 422
+    assert response.status_code == 200
     data = response.json()
-    assert "Unsupported event type" in data["detail"]
+    assert data["message"] == "Ignored unsupported event: assignment_created"
     mock_runner.assert_not_awaited()
 
 
@@ -309,13 +309,11 @@ def test_webhook_deployment_failure(
 
 
 @pytest.mark.integration
-@patch("canvas_code_correction.webhooks.server.get_rate_limiter")
 @patch("canvas_code_correction.webhooks.server.load_settings_from_course_block")
 @patch("canvas_code_correction.webhooks.server.verify_canvas_webhook")
 def test_webhook_custom_deployment_name(
     mock_verify: AsyncMock,
     mock_resolve_settings: Mock,
-    mock_get_rate_limiter: Mock,
     client: TestClient,
     mock_settings: Settings,
 ) -> None:
@@ -330,7 +328,7 @@ def test_webhook_custom_deployment_name(
     )
     mock_limiter = Mock()
     mock_limiter.hit.return_value = True
-    mock_get_rate_limiter.return_value = mock_limiter
+    webhook_server.app.dependency_overrides[webhook_server.get_rate_limiter] = lambda: mock_limiter
     mock_runner = AsyncMock()
     mock_runner.return_value = TriggerDeploymentResult(
         deployment_name="webhook-correction-flow/custom-deployment-name",
@@ -349,6 +347,7 @@ def test_webhook_custom_deployment_name(
         )
     finally:
         webhook_server.app.dependency_overrides.pop(webhook_server.get_webhook_runner, None)
+        webhook_server.app.dependency_overrides.pop(webhook_server.get_rate_limiter, None)
 
     assert response.status_code == 202
     data = response.json()

--- a/tests/unit/prefect_blocks/test_canvas_block.py
+++ b/tests/unit/prefect_blocks/test_canvas_block.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 from pydantic import SecretStr
 
+from canvas_code_correction.config import WebhookAuthMode
 from canvas_code_correction.prefect_blocks import CourseConfigBlock
 
 pytestmark = pytest.mark.usefixtures("prefect_testing_environment")
@@ -28,6 +29,8 @@ def test_course_config_block_round_trip() -> None:
         grader_upload_comments=False,
         grader_upload_grades=True,
         grader_upload_verbose=True,
+        webhook_auth_mode=WebhookAuthMode.CANVAS_SIGNED_JWT,
+        webhook_canvas_jwks_cache_seconds=1800,
     )
 
     block.save(block_name, overwrite=True)
@@ -49,5 +52,7 @@ def test_course_config_block_round_trip() -> None:
         assert loaded.grader_upload_comments is False  # type: ignore[attr-defined]
         assert loaded.grader_upload_grades is True  # type: ignore[attr-defined]
         assert loaded.grader_upload_verbose is True  # type: ignore[attr-defined]
+        assert loaded.webhook_auth_mode is WebhookAuthMode.CANVAS_SIGNED_JWT  # type: ignore[attr-defined]
+        assert loaded.webhook_canvas_jwks_cache_seconds == 1800  # type: ignore[attr-defined]
     finally:
         CourseConfigBlock.delete(block_name)

--- a/tests/unit/test_cli_setup_course.py
+++ b/tests/unit/test_cli_setup_course.py
@@ -5,10 +5,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import HttpUrl
 from typer.testing import CliRunner
 
 from canvas_code_correction import cli_course
 from canvas_code_correction.cli import app
+from canvas_code_correction.config import WebhookAuthMode
 
 
 @pytest.fixture
@@ -156,6 +158,93 @@ class TestSetupCourseNonInteractive:
 
         assert result.exit_code == 0
         mock_canvas_class.assert_called_once_with("https://canvas.instructure.com", "stdin-token")
+
+    @pytest.mark.local
+    @patch("canvas_code_correction.cli.Canvas")
+    @patch("canvas_code_correction.cli.CourseConfigBlock")
+    def test_setup_course_persists_canvas_signed_webhook_defaults(
+        self,
+        mock_block_class: MagicMock,
+        mock_canvas_class: MagicMock,
+        cli_runner: CliRunner,
+        mock_canvas_course: MagicMock,
+    ) -> None:
+        mock_canvas = MagicMock()
+        mock_canvas.get_current_user.return_value = MagicMock()
+        mock_canvas.get_course.return_value = mock_canvas_course
+        mock_canvas_class.return_value = mock_canvas
+        mock_block_class.return_value = MagicMock()
+
+        result = cli_runner.invoke(
+            app,
+            [
+                "course",
+                "setup",
+                "--no-interactive",
+                "--token",
+                "test-token",
+                "--course-id",
+                "13122436",
+                "--assets-block",
+                "test-bucket",
+                "--slug",
+                "test-course",
+            ],
+        )
+
+        assert result.exit_code == 0
+        block_kwargs = mock_block_class.call_args.kwargs
+        assert block_kwargs["webhook_auth_mode"] is WebhookAuthMode.CANVAS_SIGNED_JWT
+        assert isinstance(block_kwargs["webhook_canvas_jwks_url"], HttpUrl)
+        assert block_kwargs["webhook_enabled"] is True
+        assert block_kwargs["webhook_rate_limit"] == "10/minute"
+
+    @pytest.mark.local
+    @patch("canvas_code_correction.cli.Canvas")
+    @patch("canvas_code_correction.cli.CourseConfigBlock")
+    def test_setup_course_accepts_webhook_overrides(
+        self,
+        mock_block_class: MagicMock,
+        mock_canvas_class: MagicMock,
+        cli_runner: CliRunner,
+        mock_canvas_course: MagicMock,
+    ) -> None:
+        mock_canvas = MagicMock()
+        mock_canvas.get_current_user.return_value = MagicMock()
+        mock_canvas.get_course.return_value = mock_canvas_course
+        mock_canvas_class.return_value = mock_canvas
+        mock_block_class.return_value = MagicMock()
+
+        result = cli_runner.invoke(
+            app,
+            [
+                "course",
+                "setup",
+                "--no-interactive",
+                "--token",
+                "test-token",
+                "--course-id",
+                "13122436",
+                "--assets-block",
+                "test-bucket",
+                "--slug",
+                "test-course",
+                "--webhook-auth",
+                "hmac",
+                "--webhook-jwks-url",
+                "https://canvas.example.test/jwks",
+                "--webhook-rate-limit",
+                "2/minute",
+                "--webhook-disabled",
+            ],
+        )
+
+        assert result.exit_code == 0
+        block_kwargs = mock_block_class.call_args.kwargs
+        assert block_kwargs["webhook_auth_mode"] is WebhookAuthMode.HMAC
+        assert str(block_kwargs["webhook_canvas_jwks_url"]) == "https://canvas.example.test/jwks"
+        assert block_kwargs["webhook_enabled"] is False
+        assert block_kwargs["webhook_rate_limit"] == "2/minute"
 
     @pytest.mark.local
     def test_setup_course_token_and_token_stdin_mutually_exclusive(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,8 +9,10 @@ from pydantic import HttpUrl, SecretStr
 
 from canvas_code_correction.bootstrap import load_settings_from_course_block
 from canvas_code_correction.config import (
+    CANVAS_LIVE_EVENTS_JWKS_URL,
     CanvasSettings,
     Settings,
+    WebhookAuthMode,
     WebhookSettings,
     WorkspaceSettings,
 )
@@ -124,3 +126,30 @@ def test_webhook_settings_default() -> None:
     assert settings.enabled is True
     assert settings.require_jwt is False
     assert settings.rate_limit == "10/minute"
+    assert settings.auth_mode is None
+    assert str(settings.canvas_jwks_url).rstrip("/") == CANVAS_LIVE_EVENTS_JWKS_URL
+
+
+def test_webhook_settings_resolves_legacy_and_explicit_modes() -> None:
+    """Explicit authentication takes precedence while old fields remain supported."""
+    assert (
+        WebhookSettings(require_jwt=True).effective_auth_mode() is WebhookAuthMode.LEGACY_BEARER_JWT
+    )
+    assert WebhookSettings(secret=SecretStr("secret")).effective_auth_mode() is WebhookAuthMode.HMAC
+    assert (
+        WebhookSettings(allow_canvas_api_fallback=True).effective_auth_mode()
+        is WebhookAuthMode.CANVAS_API
+    )
+    assert (
+        WebhookSettings(
+            auth_mode=WebhookAuthMode.CANVAS_SIGNED_JWT,
+            require_jwt=True,
+        ).effective_auth_mode()
+        is WebhookAuthMode.CANVAS_SIGNED_JWT
+    )
+
+
+def test_webhook_settings_rejects_non_positive_jwk_cache_ttl() -> None:
+    """Signing keys must have a positive cache lifetime."""
+    with pytest.raises(ValueError, match="greater than 0"):
+        WebhookSettings(canvas_jwks_cache_seconds=0)

--- a/tests/unit/webhooks/test_auth.py
+++ b/tests/unit/webhooks/test_auth.py
@@ -3,7 +3,7 @@
 import json
 from collections.abc import Mapping
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import jwt.exceptions
 import requests
@@ -14,18 +14,104 @@ from canvas_code_correction.config import (
     CourseAssetsSettings,
     GraderSettings,
     Settings,
+    WebhookAuthMode,
     WebhookSettings,
     WorkspaceSettings,
 )
 from canvas_code_correction.webhooks.auth import (
     WebhookSignatureHeaders,
     WebhookVerificationResult,
+    clear_jwk_cache,
     validate_canvas_signature,
     validate_hmac_signature,
     validate_jwt_token,
     verify_canvas_webhook,
     verify_via_canvas_api,
 )
+from tests.webhooks_shared import create_canvas_webhook_payload
+
+
+def _signed_jwt_settings() -> Settings:
+    return Settings(
+        canvas=CanvasSettings(
+            api_url=HttpUrl("https://canvas.instructure.com"),
+            token=SecretStr("fake"),
+            course_id=1,
+        ),
+        assets=CourseAssetsSettings(bucket_block="test"),
+        grader=GraderSettings(),
+        workspace=WorkspaceSettings(),
+        webhook=WebhookSettings(auth_mode=WebhookAuthMode.CANVAS_SIGNED_JWT),
+    )
+
+
+def test_validate_canvas_signed_jwt_body() -> None:
+    """A verified signed body exposes its decoded Canvas event payload."""
+    settings = _signed_jwt_settings()
+    response = MagicMock()
+    response.json.return_value = {
+        "keys": [{"kid": "current", "kty": "RSA", "alg": "RS256", "n": "x", "e": "AQAB"}],
+    }
+    key = MagicMock()
+    key.key = object()
+    clear_jwk_cache()
+    with (
+        patch("canvas_code_correction.webhooks.auth.requests.get", return_value=response),
+        patch(
+            "canvas_code_correction.webhooks.auth.jwt.get_unverified_header",
+            return_value={"kid": "current", "alg": "RS256"},
+        ),
+        patch("canvas_code_correction.webhooks.auth.jwt.PyJWK.from_dict", return_value=key),
+        patch(
+            "canvas_code_correction.webhooks.auth.jwt.decode",
+            return_value=create_canvas_webhook_payload(),
+        ),
+    ):
+        result = validate_canvas_signature(settings, b"signed.jwt.body", WebhookSignatureHeaders())
+
+    assert result.success is True
+    assert result.mode == "canvas-signed-jwt"
+    assert result.payload is not None
+    assert result.payload.metadata.event_name == "submission_created"
+
+
+def test_validate_canvas_signed_jwt_refresh_failure_returns_bad_gateway() -> None:
+    """An unavailable JWK endpoint is retryable when no cached key exists."""
+    clear_jwk_cache()
+    with (
+        patch(
+            "canvas_code_correction.webhooks.auth.jwt.get_unverified_header",
+            return_value={"kid": "new", "alg": "RS256"},
+        ),
+        patch(
+            "canvas_code_correction.webhooks.auth.requests.get",
+            side_effect=requests.Timeout,
+        ),
+    ):
+        result = validate_canvas_signature(
+            _signed_jwt_settings(),
+            b"signed.jwt.body",
+            WebhookSignatureHeaders(),
+        )
+
+    assert result.status_code == 502
+    assert result.success is False
+
+
+def test_validate_canvas_signed_jwt_rejects_symmetric_algorithm() -> None:
+    """Signed Canvas events never accept attacker-selected symmetric algorithms."""
+    with patch(
+        "canvas_code_correction.webhooks.auth.jwt.get_unverified_header",
+        return_value={"kid": "current", "alg": "HS256"},
+    ):
+        result = validate_canvas_signature(
+            _signed_jwt_settings(),
+            b"signed.jwt.body",
+            WebhookSignatureHeaders(),
+        )
+
+    assert result.status_code == 401
+    assert result.success is False
 
 
 def test_validate_jwt_token_valid() -> None:

--- a/tests/unit/webhooks/test_server.py
+++ b/tests/unit/webhooks/test_server.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from canvas_code_correction.bootstrap import CourseBlockLoadError
+from canvas_code_correction.config import WebhookAuthMode
 from canvas_code_correction.webhooks import server as webhook_server
 from canvas_code_correction.webhooks.auth import WebhookVerificationResult
 from canvas_code_correction.webhooks.deployments import TriggerDeploymentResult
@@ -86,6 +87,48 @@ def test_handle_canvas_webhook_success(
         payload_arg = call_args.args[3]
     assert isinstance(payload_arg, CanvasWebhookPayload)
     assert payload_arg.get_event_type() == "submission_created"
+    mock_runner.assert_awaited_once_with(mock_settings, "test-course", 123, 456)
+
+
+@patch("canvas_code_correction.webhooks.server.load_settings_from_course_block")
+def test_handle_canvas_signed_jwt_body_before_json_parsing(
+    mock_resolve_settings: AsyncMock,
+    client: TestClient,
+    mock_settings: Settings,
+) -> None:
+    """Signed Live Events are verified and decoded before JSON parsing."""
+    mock_settings.webhook.auth_mode = WebhookAuthMode.CANVAS_SIGNED_JWT
+    mock_resolve_settings.return_value = mock_settings
+    canvas_payload = CanvasWebhookPayload.model_validate(create_canvas_webhook_payload())
+    mock_runner = AsyncMock(
+        return_value=TriggerDeploymentResult(
+            deployment_name="test-deployment",
+            success=True,
+            flow_run_id="signed-flow-run",
+        ),
+    )
+    webhook_server.app.dependency_overrides[webhook_server.get_webhook_runner] = lambda: mock_runner
+    try:
+        with patch(
+            "canvas_code_correction.webhooks.server.verify_canvas_webhook",
+            return_value=WebhookVerificationResult(
+                success=True,
+                message="verified",
+                status_code=200,
+                mode="canvas-signed-jwt",
+                payload=canvas_payload,
+            ),
+        ) as mock_verify:
+            response = client.post(
+                "/webhooks/canvas/test-course",
+                content=b"compact.jwt.body",
+            )
+    finally:
+        webhook_server.app.dependency_overrides.pop(webhook_server.get_webhook_runner, None)
+
+    assert response.status_code == 202
+    mock_verify.assert_called_once()
+    assert mock_verify.call_args.args[1] == b"compact.jwt.body"
     mock_runner.assert_awaited_once_with(mock_settings, "test-course", 123, 456)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1440,7 +1440,7 @@ name = "jinxed"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/e9/96633f12b6829eb1e91e70e5846704c0b1293ec47bd65a7b681e19c8eeff/jinxed-1.4.0.tar.gz", hash = "sha256:8f7801a10799de39e509eb5abc6d131ee169c1ce4fd5d568aa85b5f56ed58068", size = 37169, upload-time = "2026-03-26T01:49:38.337Z" }
 wheels = [
@@ -2540,11 +2540,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- verify Canvas Live Events signed JWT bodies against rotating Canvas JWKs
- persist signed-event authentication settings in course blocks and CLI setup
- retain explicit legacy bearer JWT, HMAC, and Canvas API modes
- cover authentication, configuration, CLI, server, and integration behavior

## Stack

This is layer 1 of 3 and targets main.

## Checks

- uv run pytest tests/unit -q --strict-markers
- uv run pytest tests/integration/webhooks -q --strict-markers -m integration --no-cov
- uv run ruff format --check .
- uv run ruff check .
- uv run pyrefly check src
- commit hooks

---

## Review findings

Multi-agent review (3 independent reviewers) — full detail in [this comment](https://github.com/jakob1379/Canvas-Code-Correction/pull/153#issuecomment-5301956076). All three verdicts: block. Baseline is green (82 unit + 13 integration, ruff clean, `auth.py` 86%).

**High**

- [ ] Bind the verified event to `settings.canvas.course_id` — `auth.py:234-240` decodes with no `audience`/`issuer` and never checks claims against the course, so a signature proves "signed by this JWKS", not "for this course" (~2 lines; `CanvasWebhookMetadata` already parses `context_id`)
- [ ] Drop `options={"verify_exp": False}` and add an `event_time` freshness window — `auth.py:238`; verified: a token with `exp` 1h in the past returns 200
- [ ] Add one real-signature test + wrong-key negative — `tests/unit/webhooks/test_auth.py:48-75` mocks `get_unverified_header`, `PyJWK.from_dict` *and* `jwt.decode`; `auth.py:221,230,232,248-249` never execute, so `"verify_signature": False` would ship green
- [ ] Move the JWKS fetch off the event loop — `auth.py:52` does a blocking `requests.get(timeout=10)` inside `async def validate_webhook`, now on the default path for every new course

**Medium**

- [ ] `"PyJWT[crypto]>=2.12.0"` — `pyproject.toml:39`; `cryptography` currently resolves only via `mcp`'s `pyjwt[crypto]`, and the resulting `PyJWKError` is swallowed at `auth.py:248` into a generic 401
- [ ] Bound the stale-key fallback and write it back to cache — `auth.py:74-85`; a revoked key stays trusted indefinitely during a JWKS outage
- [ ] Add negative caching — `auth.py:69-85`; measured 5 unknown-kid requests → 5 upstream fetches
- [ ] Return 422 (not 401) for schema-valid-signature/invalid-body — `auth.py:240` + `server.py:221-233`; a signed `submission_updated` lacking `submitted_at` currently reads as an auth failure
- [ ] Remove or complete `--webhook-auth hmac` / `legacy-bearer-jwt` — `cli_course.py:441-445`; no `--webhook-secret` exists, so they persist a config that 401s, and `tests/unit/test_cli_setup_course.py:232-247` asserts that broken state saves
- [ ] Split out the integration-test repair — `test_webhook_signals.py:161-163` flips an assertion while `handler.py` is byte-identical to base; that test was red on `main` (integration is deselected by default)

**Low**

- [ ] Drop the dead `getattr(block, "webhook_*", ...)` guards and the duplicated JWKS URL — `bootstrap.py:92-107`
- [ ] Reject `http://` for `canvas_jwks_url` — `config.py:105`
- [ ] Unify `result.mode` strings — `auth.py:246` emits `canvas-signed-jwt`, `:124/:360` emit `jwt` / `canvas_api`
- [ ] Narrow `_ASYMMETRIC_JWT_ALGORITHMS` to RS256 — `auth.py:30`
- [ ] Reset `_jwk_cache` between tests — `auth.py:39`
- [ ] Refresh the `validate_canvas_signature` docstring (`auth.py:370-375`) and finish closing the deleted "Known Gap": `allow_canvas_api_fallback` has no setup flag and is bypassable via `--webhook-auth canvas-api` (`config.py:110-117`)
- [ ] List the new flags in `docs/reference/02-cli.md:58-72`

**Simplification (~150 lines, optional)**

- [ ] Replace the hand-rolled JWKS cache with `jwt.PyJWKClient` — `auth.py:33-85`. Keep the JWK-vs-header `alg` cross-check (re-assert via `key.algorithm_name`); it is what closes HS256 key confusion
- [ ] Drop `canvas_jwks_cache_seconds` (not CLI- or env-settable, no non-default caller) and the unreachable `verification.payload is None` branch at `server.py:228-232`
