### PR TITLE
chore(lint): adopt ruff 0.16 formatting and rule set

### DIFF
--- a/docs/reference/04-api-clients.md
+++ b/docs/reference/04-api-clients.md
@@ -125,9 +125,7 @@ feedback_file = Path("feedback.zip")
 grade = "95"
 
 config = UploadConfig(check_duplicates=True, dry_run=False)
-feedback_result, grade_result = uploader.upload_feedback_and_grade(
-    feedback_file, grade, config
-)
+feedback_result, grade_result = uploader.upload_feedback_and_grade(feedback_file, grade, config)
 
 print(feedback_result.message)
 print(grade_result.message)

--- a/docs/reference/06-authoring-grader-tests.md
+++ b/docs/reference/06-authoring-grader-tests.md
@@ -26,11 +26,7 @@ WORKSPACE_ROOT = Path(os.getenv("CCC_WORKSPACE_DIR", Path.cwd()))
 
 def submission_files(root: Path) -> list[str]:
     """Return sorted relative paths of all files under `root`."""
-    return sorted(
-        path.relative_to(root).as_posix()
-        for path in root.rglob("*")
-        if path.is_file()
-    )
+    return sorted(path.relative_to(root).as_posix() for path in root.rglob("*") if path.is_file())
 
 
 def write_outputs(files: list[str]) -> None:

--- a/docs/tutorial/04-writing-grader-tests.md
+++ b/docs/tutorial/04-writing-grader-tests.md
@@ -48,6 +48,7 @@ RESULTS_PATH = Path(os.getenv("CCC_RESULTS_FILE", WORKSPACE_ROOT / "results.json
 POINTS_PATH = Path(os.getenv("CCC_POINTS_FILE", WORKSPACE_ROOT / "points.txt"))
 COMMENTS_PATH = Path(os.getenv("CCC_COMMENTS_FILE", WORKSPACE_ROOT / "comments.txt"))
 
+
 def main() -> None:
     submission_root = WORKSPACE_ROOT / "submission"
 
@@ -78,6 +79,7 @@ def main() -> None:
     COMMENTS_PATH.write_text("\n".join(comment_lines) + "\n")
 
     print("✅ Grader finished successfully")
+
 
 if __name__ == "__main__":
     main()
@@ -181,6 +183,7 @@ common patterns.
 ```python
 import subprocess
 
+
 def run_pytest(submission_root: Path) -> tuple[int, str]:
     """Run pytest and return (exit_code, stdout)."""
     # Install dependencies if needed (use a requirements.txt in your grader image)
@@ -198,6 +201,7 @@ def run_pytest(submission_root: Path) -> tuple[int, str]:
 
 ```python
 REQUIRED_FILES = {"main.py", "README.md"}
+
 
 def check_required_files(submission_root: Path) -> list[str]:
     missing = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,10 @@ quote-style = "double"
 select = [
   "ALL"
 ]
-ignore = []
+ignore = [
+  # Stabilised in ruff 0.16; this project ships no per-file copyright headers.
+  "CPY001"
+]
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["typer.Option", "typer.Argument"]
@@ -137,7 +140,7 @@ known-first-party = ["canvas_code_correction"]
 
 [tool.ruff.lint.per-file-ignores]
 # Allow assert statements and skip docstrings in tests
-"tests/**/*.py" = ["S101", "D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107", "INP001", "PLR0913", "PLR2004", "ANN001", "ANN201", "ARG001", "FBT001", "PLR0915", "S108", "PLC0415", "N818", "SIM117", "RET504", "SLF001", "S105", "TC003", "TRY300", "T201"]
+"tests/**/*.py" = ["S101", "D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107", "INP001", "PLR0913", "PLR0917", "PLR2004", "ANN001", "ANN201", "ARG001", "FBT001", "PLR0915", "S108", "PLC0415", "N818", "SIM117", "RET504", "SLF001", "S105", "TC003", "TRY300", "T201"]
 # Ignore all linting issues in development scripts
 "scripts/**/*.py" = ["ALL"]
 "src/canvas_code_correction/cli.py" = ["ANN", "ARG", "COM", "D", "E", "F", "FBT", "I", "N", "PLR", "UP"]


### PR DESCRIPTION
Follow-up to #160, which bumped ruff 0.15.22 → 0.16.1 and left `main` red.

The new ruff version:
- reformats three markdown code blocks in `docs/`
- stabilises `CPY001` (flake8-copyright) and `PLR0917` (too-many-positional-arguments), both of which `select = ["ALL"]` now picks up — 74 new errors

Fix: run `ruff format`, ignore `CPY001` globally (this project ships no per-file copyright headers), and ignore `PLR0917` in tests next to the existing `PLR0913`.

Verified locally: `ruff format --check`, `ruff check`, `pyrefly check src`, `uv run poe ci:audit`, and `pytest tests/unit` (216 passed) all pass.